### PR TITLE
docs: update org profile status to public/self-service

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -148,11 +148,11 @@ We stand on the shoulders of giants. mctl orchestrates best-in-class open source
 
 ## Current Status
 
-mctl is currently in a private beta phase. Access to the repositories, documentation, and the hosted control plane is restricted to invited teams. 
+mctl is open source. All platform repositories are public under Apache 2.0. Sign in with GitHub at [mctl.ai](https://mctl.ai) to self-provision a tenant on the hosted control plane — no invitation required.
 
 <div align="center">
   <br />
-  <a href="https://mctl.ai">mctl.ai</a> &nbsp;&bull;&nbsp; <a href="mailto:support@mctl.ai">support@mctl.ai</a>
+  <a href="https://mctl.ai">mctl.ai</a> &nbsp;&bull;&nbsp; <a href="https://docs.mctl.ai">docs.mctl.ai</a> &nbsp;&bull;&nbsp; <a href="mailto:support@mctl.ai">support@mctl.ai</a>
 </div>
 
 <!-- SEO Tags: mcp, mcp-server, model-context-protocol, claude-connector, gemini-mcp, gemini-cli, kubernetes, k8s, gitops, argocd, platform-engineering, developer-portal, self-healing, ai-agent, mcp.so -->


### PR DESCRIPTION
## Summary
- Repos went public 2026-07-03 (rulesets, secret scanning, Dependabot enabled).
- Tenant creation is self-service via mctl.ai GitHub OAuth (docs already describe this flow).
- The profile README's "Current Status" section still said private-beta/invite-only, contradicting both reality and mctl-docs' own FAQ ("All repositories are licensed under Apache 2.0 and available on GitHub").

## Test plan
- [x] Rendered profile README locally (markdown preview) — links resolve, no broken formatting