### PR TITLE
docs: add pr-steward and Tier-1 path to AI Automation Loop diagram

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -148,12 +148,16 @@ graph LR
 
   Alert(["Alert<br/>(AlertManager)"]):::trig --> SelfHeal(["mctl-agent<br/>AI diagnosis"]):::agent
   Issue(["GitHub issue"]):::trig --> Investigator(["investigator<br/>agent"]):::agent
+  Scan(["Scheduled scan"]):::trig --> Tier1(["service agents<br/>+ mentor"]):::agent
+  TeamPR(["team & bot PRs"]):::trig --> Review(["AI code review<br/>0 unaddressed P1/P2"]):::gate
   Investigator -- proposal --> Implementer(["implementer<br/>agent"]):::agent
-  SelfHeal -- remediation PR --> Review(["AI code review<br/>0 unaddressed P1/P2"]):::gate
+  Tier1 -- proposal --> Implementer
+  SelfHeal -- remediation PR --> Review
   Implementer -- implementation PR --> Review
   Review -- findings --> Shepherd(["PR shepherd<br/>fix loop"]):::agent
   Shepherd -- fix push --> Review
   Review -- clean --> Merge(["merge"]):::done
+  Steward(["pr-steward<br/>PR watchdog"]):::agent -- merge when green --> Merge
   Merge --> Sync(["ArgoCD sync<br/>to cluster"]):::done
   Skills(["platform skills catalog<br/>GitOps · served over MCP"]):::gate
   Skills -.-> SelfHeal


### PR DESCRIPTION
The AI Automation Loop diagram was missing two platform agents:

- **Tier-1 proactive path**: scheduled scan → service agents + mentor → proposals → implementer
- **pr-steward**: the PR watchdog loop that merges team & bot PRs when the review gate and CI are green (separate from the Tier-3 shepherd, which owns agent-PR fix loops)

Mermaid validated locally with mermaid-cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)