### PR TITLE
ci: add shared reusable claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,603 @@
+name: Claude PR review (reusable)
+
+# Shared automated code reviewer for every mctlhq repository. Ported from
+# mctl-telegram's claude-review.yml, which had accumulated hardening the other
+# 16 copies never received (gate/review split, SHA-scoped concurrency,
+# immutable base...head diff, dedup, staleness, narrowed allowedTools).
+#
+# Callers keep their own triggers and pin this by SHA:
+#
+#   name: Claude PR review
+#   on:
+#     pull_request:
+#       types: [opened, reopened, synchronize, ready_for_review]
+#     issue_comment:
+#       types: [created]
+#   permissions: {}
+#   jobs:
+#     claude-review:
+#       uses: mctlhq/.github/.github/workflows/claude-review.yml@<SHA>
+#       permissions:
+#         contents: read
+#         pull-requests: write
+#         issues: write
+#         id-token: write
+#       with:
+#         sensitive-paths: '^internal/(auth|crypto|db)/'
+#       secrets:
+#         CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+#         CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+#
+# NOTE for callers with branch protection: a reusable workflow reports its
+# check as "<caller job name> / <called job name>", never as a bare job name.
+# Any required status check naming the old job must be updated in the same
+# window, or the gate will wait forever on a context that no longer reports.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: Runner label for both jobs.
+        type: string
+        default: ubuntu-latest
+      sensitive-paths:
+        description: >
+          Extended regex (grep -E) matching paths that force the top model
+          tier. Empty disables the check, leaving size and "is it code" as the
+          only signals.
+        type: string
+        default: ''
+      code-paths:
+        description: >
+          Extended regex matching non-test source files that warrant at least
+          the middle tier. Defaults to common compiled/scripting extensions.
+        type: string
+        default: '\.(go|ts|tsx|js|jsx|py|rs|java|rb)$'
+      test-paths:
+        description: Extended regex matching test files, excluded from code-paths.
+        type: string
+        default: '(_test\.(go|py|rb)|\.(test|spec)\.(ts|tsx|js|jsx))$'
+      model-high:
+        description: Model for security-sensitive or large diffs.
+        type: string
+        default: claude-sonnet-5
+      model-mid:
+        description: Model for ordinary source changes.
+        type: string
+        default: claude-sonnet-5
+      model-low:
+        description: Model for docs/config-only diffs.
+        type: string
+        default: claude-haiku-4-5-20251001
+      allowed-bots:
+        description: >
+          Comma-separated bot actors whose pushes may still be reviewed.
+          Without an entry the action hard-fails with "Workflow initiated by
+          non-human actor" on synchronize events from the mctl-agents pipeline.
+        type: string
+        default: mctl-claude-remote,github-actions
+      conventions:
+        description: >
+          Extra repository-specific guidance appended to the review prompt
+          (language, style, commit format). Untrusted PR content never reaches
+          this — it comes from the caller's own workflow file.
+        type: string
+        default: ''
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+      CLAUDE_CODE_OAUTH_TOKEN_2:
+        required: false
+
+jobs:
+  # Split into gate + review (2026-07-22, Claude review round on
+  # mctl-telegram#309 caught this): the hard write-permission/fork check must
+  # complete BEFORE the job enters the review job's canceling concurrency
+  # group. If both lived in one job, the coarse author_association pre-filter
+  # below is enough for a read-only collaborator's comment to pass the
+  # job-level `if:` and enter the concurrency group — with
+  # cancel-in-progress: true that cancels any currently-running legitimate
+  # review, and only THEN does the (now pointless) hard permission check fail.
+  # Splitting means the unauthorized run fails in `gate` and never touches the
+  # concurrency group at all.
+  gate:
+    # pull_request: skip drafts and fork PRs (CLAUDE_CODE_OAUTH_TOKEN unavailable to forks)
+    # issue_comment: only fire on PR comments containing '@claude review'
+    # from a maintainer (association pre-filter here; hard write-permission +
+    # same-repo check in the step below) — on a public repo an ungated
+    # comment trigger lets any passerby burn review quota or prompt-inject
+    # the reviewer.
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@claude review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    runs-on: ${{ inputs.runner }}
+    # Read-only: this job only queries collaborator permission and PR
+    # cross-repo status, both GET calls — it never writes anything, so it
+    # needs no more than read access even though the downstream review job
+    # (gated by needs: gate) has pull-requests: write for posting comments.
+    permissions:
+      contents: read
+      pull-requests: read
+    # Consumed by `review` via needs.gate.outputs.* — see the "Resolve PR
+    # ref" and "Staleness check" steps below for why both freshness
+    # validation and (for issue_comment) ref/sha resolution live here rather
+    # than as steps inside `review` itself.
+    outputs:
+      ref: ${{ steps.pr-ref.outputs.ref }}
+      sha: ${{ github.event.pull_request.head.sha || steps.pr-ref.outputs.sha }}
+      base_sha: ${{ github.event.pull_request.base.sha || steps.pr-ref.outputs.base_sha }}
+      stale: ${{ steps.staleness.outputs.stale }}
+    steps:
+      # author_association alone is too coarse (MEMBER = any org member,
+      # COLLABORATOR includes read-only). Require actual write access, and
+      # refuse comment-triggered runs on fork PRs — the review job would
+      # check out refs/pull/N/head, making fork-controlled files the
+      # workspace while the OAuth secret is available.
+      - name: Gate comment-triggered runs (write permission + same-repo)
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          PERM=$(gh api "repos/$REPO/collaborators/$COMMENTER/permission" --jq .permission)
+          case "$PERM" in
+            admin|maintain|write) ;;
+            *) echo "::error::@claude review requires write access (commenter has: $PERM)"; exit 1 ;;
+          esac
+          CROSS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isCrossRepository --jq .isCrossRepository)
+          if [ "$CROSS" != "false" ]; then
+            echo "::error::comment-triggered review is not supported on fork PRs"
+            exit 1
+          fi
+
+      - name: Resolve PR branch for issue_comment trigger
+        if: github.event_name == 'issue_comment'
+        id: pr-ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          read -r ref sha base_sha < <(
+            gh pr view "$PR_NUMBER" \
+              --repo "$REPO" \
+              --json headRefName,headRefOid,baseRefOid \
+              --jq '[.headRefName, .headRefOid, .baseRefOid] | @tsv'
+          )
+          {
+            echo "ref=$ref"
+            echo "sha=$sha"
+            echo "base_sha=$base_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      # Deliberately runs in `gate`, BEFORE `review` ever enters its
+      # canceling concurrency group — a Codex finding on mctl-telegram#309
+      # caught that this check originally lived as a step inside `review`,
+      # which means the job had ALREADY entered the concurrency group (and,
+      # with cancel-in-progress: true, potentially already cancelled a
+      # currently-running newer/correct review) by the time staleness was
+      # even evaluated. The check itself catching "I'm stale" after that
+      # point is too late — the damage (killing the good review) already
+      # happened. Running it here means a stale run fails before it ever
+      # touches the concurrency group at all, exactly like the
+      # write-permission check above it. Note it compares the event's own
+      # head SHA rather than a post-checkout `git rev-parse HEAD`: nothing is
+      # checked out in this job, and the event SHA is what everything
+      # downstream is pinned to.
+      - name: Reject if this run's commit is no longer the PR's current head
+        id: staleness
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          TRIGGERED_FOR: ${{ github.event.pull_request.head.sha || steps.pr-ref.outputs.sha }}
+        run: |
+          current_head=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q .headRefOid)
+          if [ "$TRIGGERED_FOR" != "$current_head" ]; then
+            echo "::notice::stale run — triggered for $TRIGGERED_FOR but PR head is now $current_head; skipping"
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  review:
+    needs: gate
+    if: needs.gate.outputs.stale != 'true'
+    runs-on: ${{ inputs.runner }}
+    # Bounds mid-flight duplication: pull_request (auto, on every push) and a
+    # manual '@claude review' comment on the same commit are two independent
+    # triggers for the workflow, and nothing before this stopped both runs
+    # completing in parallel. cancel-in-progress only stops the SECOND of two
+    # overlapping runs (the first may already have spent tokens/posted inline
+    # comments before cancellation lands) — paired with the "already
+    # reviewed" preflight check below, which turns the common case (comment
+    # posted right after the auto-triggered run already finished) into a
+    # near-zero-cost early exit instead. Only entered after `gate` succeeds —
+    # see the job-split comment above for why.
+    #
+    # Scoped to the SHA, not just the PR number — a Codex finding caught
+    # that a PR-wide group still let an OLDER commit's run cancel a NEWER
+    # commit's run: gate's staleness check is only a point-in-time snapshot,
+    # and there's an unavoidable gap between gate finishing and review
+    # actually entering the group, during which a fresh push can land and
+    # make an already-"fresh" cached result stale by the time it matters.
+    # GitHub's concurrency cancellation has no notion of "older vs newer" —
+    # it only knows "who was already in the group when a second entrant
+    # arrived" — so a PR-wide group can cancel a legitimately newer run
+    # regardless of gate's own check. Keying the group by SHA instead means
+    # two DIFFERENT commits' reviews never share a group and can never
+    # cancel each other at all; cancel-in-progress then only ever fires
+    # between two triggers for the IDENTICAL commit (the actual redundant-
+    # trigger case this was meant to solve — push immediately followed by
+    # a manual @claude review comment on that same push).
+    concurrency:
+      group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ needs.gate.outputs.sha }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    env:
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+      BASE_SHA: ${{ needs.gate.outputs.base_sha }}
+      HEAD_SHA: ${{ needs.gate.outputs.sha }}
+      # The primary and the fallback invocation must send the IDENTICAL
+      # prompt. In the donor workflow both copies were written out inline and
+      # had to be kept in sync by hand — 90 duplicated lines whose divergence
+      # nothing would have caught. Defined once here and referenced from both
+      # steps via the env context, which `steps.*.with` supports.
+      REVIEW_PROMPT: |
+        REPO: ${{ github.repository }}
+        PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        BASE SHA: ${{ needs.gate.outputs.base_sha }}
+        COMMIT SHA: ${{ needs.gate.outputs.sha }}
+
+        You are the automated code reviewer for this pull request. Review
+        the immutable diff thoroughly. Use exactly:
+        `git diff ${{ needs.gate.outputs.base_sha }}...${{ needs.gate.outputs.sha }}`
+        Never use `gh pr diff` or `gh pr view`: those read mutable PR data
+        and may point at a newer commit while this invocation is running.
+        Files in the checkout and both git object IDs are pinned.
+
+        Focus on:
+        - Correctness and logic errors; edge cases the change misses.
+        - Security: injection, authentication/authorization, secret
+          handling, unsafe input.
+        - Concurrency: data races, deadlocks, goroutine leaks.
+        - Error handling: ignored errors, missing context, panics.
+        - Test coverage: behaviour changed without a corresponding test.
+
+        Follow the conventions in this repository's CLAUDE.md and AGENTS.md.
+        ${{ inputs.conventions }}
+
+        IMPORTANT: this run's review target is pinned to the COMMIT SHA
+        above, not just the PR number. This SHA-scoped concurrency group
+        deliberately allows an older commit's review to keep running
+        alongside a newer commit's review instead of being cancelled, so
+        by the time you submit your verdict the PR's current head may
+        already be a later commit than the one you analyzed. Always
+        submit the verdict against COMMIT SHA explicitly — never rely on
+        a command that defaults to "the PR's current head" — or your
+        verdict for this (possibly now-outdated) commit could be silently
+        recorded against a commit you never reviewed.
+
+        If the diff is trivial — only config/values YAML (hostname, env
+        var, image tag, resource limits, replica count), a dependency bump
+        with no logic change, docs/comments, or a one-line typo — approve
+        the PR with a one-line reason and nothing else:
+        `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews --method POST -f commit_id="${{ needs.gate.outputs.sha }}" -f event="APPROVE" -f body="<reason>"`.
+
+        Otherwise, post each finding as an inline review comment using
+        the commit-bound REST call below, prefixed with a severity tag:
+        - P1 — must fix before merge (bug, security hole, data loss).
+        - P2 — should fix before merge (likely bug, missing test, unsafe
+          pattern).
+        - P3 — nice to have (style, minor nit); does not block merge.
+
+        Bind every inline comment to COMMIT SHA explicitly:
+        `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/comments --method POST -f commit_id="${{ needs.gate.outputs.sha }}" -f path="<repo-relative path>" -F line=<new-file line> -f side="RIGHT" -f body="<P1/P2/P3 finding>"`
+        Never omit commit_id. If the relevant line exists only on the
+        removed side, use `side="LEFT"` and its old-file line number.
+
+        Finish by submitting a single PR review verdict (this is the merge
+        gate — `main` requires one approving review). Include the P1/P2/P3
+        counts in the body; be concise and do not restate the diff. Both
+        commands below explicitly bind the verdict to COMMIT SHA — do not
+        omit -f commit_id or use `gh pr review` instead, which implicitly
+        targets whatever the PR's current head happens to be at submit
+        time, not the commit you actually analyzed:
+        - No P1/P2 findings (P3 nits are fine): approve —
+          `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews --method POST -f commit_id="${{ needs.gate.outputs.sha }}" -f event="APPROVE" -f body="No P1/P2 findings (<n> P3). Good to merge."`
+        - One or more P1/P2 findings: request changes —
+          `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews --method POST -f commit_id="${{ needs.gate.outputs.sha }}" -f event="REQUEST_CHANGES" -f body="Has P1/P2 findings, changes requested: <summary>"`
+    steps:
+      # A push already auto-triggers a review for its own commit via the
+      # pull_request/synchronize path — a manual '@claude review' comment
+      # posted right after is only ever redundant with that, never with
+      # itself. Checks this specific PR's own review list (via the GitHub
+      # reviews API, which records the exact commit_id each review was
+      # submitted against) for an existing TERMINAL VERDICT from claude[bot]
+      # on the current head SHA — NOT workflow-run history, and not just "any
+      # review record at all". Two rounds of review on this workflow itself
+      # (mctl-telegram#309) caught successive gaps here:
+      #   1. A run-history check treated a job whose overall conclusion was
+      #      "success" as "reviewed" even when the underlying Claude call
+      #      failed (continue-on-error masks it) — silently blocking the
+      #      exact manual retry the failure-notify comment invites. Fixed
+      #      by switching to the PR's own posted reviews instead of run
+      #      history.
+      #   2. That fix still matched ANY review record for this commit,
+      #      including bare COMMENTED entries the action posts for each
+      #      inline finding before it ever reaches the final verdict call — a
+      #      run that posted inline findings and then crashed before
+      #      submitting a verdict would still count as "already reviewed",
+      #      again blocking the retry. Filtering state to APPROVED or
+      #      CHANGES_REQUESTED (the only two terminal verdict states this
+      #      workflow's prompt ever submits) requires a REAL verdict, not
+      #      just review activity, to count as done.
+      #   3. The unpaginated API call only returns the first page (30
+      #      items) — directly observed hitting this limit on PRs with
+      #      several rounds of review records. --paginate aggregates every
+      #      page so a recent verdict past page 1 is never missed.
+      #   4. This step originally re-fetched the PR's head SHA fresh here,
+      #      instead of using needs.gate.outputs.sha — the same SHA
+      #      checkout, concurrency, and the verdict-binding prompt are all
+      #      pinned to. A push landing between gate and this step made the
+      #      two diverge: dedup would check whether the NEW head already had
+      #      a verdict (almost always no, since it just arrived), while
+      #      checkout/review still targeted the OLD, already-pinned SHA — so
+      #      an already-reviewed old commit got needlessly re-reviewed,
+      #      exactly the redundant-session waste this check exists to
+      #      prevent. Querying the same pinned SHA everything else uses keeps
+      #      them consistent.
+      - name: Skip if this commit was already reviewed
+        # Originally issue_comment-only — a Codex finding on
+        # mctl-telegram#309 caught that closing+reopening a PR, or
+        # draft->ready_for_review, refires `pull_request` for the SAME head
+        # SHA (no new commit) and bypassed this check entirely, paying for a
+        # fully redundant session. Runs for every trigger type now; the check
+        # is cheap (one paginated API call) relative to a full Claude session.
+        id: dedup
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          already=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and .commit_id == "'"$HEAD_SHA"'" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED"))] | length' | \
+            jq -s 'add > 0')
+          echo "already_reviewed=$already" >> "$GITHUB_OUTPUT"
+          if [ "$already" = "true" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "Skipping — this commit ($HEAD_SHA) already has a Claude review verdict. Push a new commit, or check the run log if you expected a fresh pass and the previous run actually failed."
+          fi
+
+      # Checks out the immutable SHA (needs.gate.outputs.sha), not the
+      # mutable branch name — a Codex finding caught that using the branch
+      # name for issue_comment runs meant a push landing between gate's
+      # resolution and this checkout would pull the NEW tip, while the
+      # concurrency group above was keyed to the OLD sha gate captured:
+      # this run would review commit B under commit A's group, and B's own
+      # separate auto-triggered run (in its own, correctly-keyed group)
+      # would review the same commit concurrently — two paid sessions
+      # analyzing the identical code instead of one. A SHA is a valid
+      # actions/checkout ref, so pinning to it costs nothing.
+      - name: Checkout
+        if: steps.dedup.outputs.already_reviewed != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # The review and complexity classifier use an immutable
+          # base-sha...head-sha diff. Full history guarantees the merge base
+          # is present without fetching a mutable branch during the review.
+          fetch-depth: 0
+          ref: ${{ needs.gate.outputs.sha }}
+
+      - name: Classify PR complexity and pick model
+        id: classify
+        if: steps.dedup.outputs.already_reviewed != 'true'
+        env:
+          # Caller-supplied regexes arrive as environment values, never
+          # interpolated into the script body: `${{ }}` splicing would let a
+          # caller's pattern terminate the surrounding quoting.
+          SENSITIVE_PATHS: ${{ inputs.sensitive-paths }}
+          CODE_PATHS: ${{ inputs.code-paths }}
+          TEST_PATHS: ${{ inputs.test-paths }}
+          MODEL_HIGH: ${{ inputs.model-high }}
+          MODEL_MID: ${{ inputs.model-mid }}
+          MODEL_LOW: ${{ inputs.model-low }}
+        run: |
+          # Read only the immutable commit pair captured by gate. Never query
+          # the live PR here: its head may move while this run is active.
+          files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          lines=$(git diff --numstat "$BASE_SHA...$HEAD_SHA" |
+            awk '{ if ($1 ~ /^[0-9]+$/) added += $1; if ($2 ~ /^[0-9]+$/) removed += $2 } END { print added + removed + 0 }')
+
+          # Score: 3=high, 2=mid, 1=low
+          score=1
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            if [ -n "$SENSITIVE_PATHS" ] && printf '%s' "$f" | grep -qE "$SENSITIVE_PATHS"; then
+              score=3; break
+            elif printf '%s' "$f" | grep -qE "$CODE_PATHS" && ! printf '%s' "$f" | grep -qE "$TEST_PATHS"; then
+              [ "$score" -lt 2 ] && score=2
+            fi
+          done <<< "$files"
+
+          # Large diffs bump one tier (up to the top).
+          if [ "$lines" -gt 400 ] && [ "$score" -lt 3 ]; then
+            score=$((score + 1))
+          fi
+
+          case "$score" in
+            3) model="$MODEL_HIGH" ;;
+            2) model="$MODEL_MID" ;;
+            *) model="$MODEL_LOW" ;;
+          esac
+
+          {
+            echo "model=$model"
+            echo "score=$score"
+            echo "lines=$lines"
+          } >> "$GITHUB_OUTPUT"
+          echo "Pinned diff $BASE_SHA...$HEAD_SHA: model=$model score=$score lines=$lines"
+
+      # Avoid spending a session if the run became stale before Claude starts.
+      # Correctness no longer depends on this point-in-time check: complexity,
+      # review input, inline comments, and the verdict are all bound to the
+      # immutable base/head pair even if a newer push lands during Claude's
+      # invocation.
+      - name: Re-check staleness immediately before the review call
+        id: prerun-staleness
+        if: steps.dedup.outputs.already_reviewed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          current_head=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q .headRefOid)
+          if [ "$HEAD_SHA" != "$current_head" ]; then
+            echo "::notice::stale before Claude call — pinned $HEAD_SHA but PR head is now $current_head; skipping"
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check fallback token availability
+        id: token-check
+        if: steps.dedup.outputs.already_reviewed != 'true'
+        env:
+          TOKEN2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+        run: |
+          if [ -n "$TOKEN2" ]; then
+            echo "has_fallback=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_fallback=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Claude review
+        id: review
+        if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: ${{ inputs.allowed-bots }}
+          track_progress: true
+          prompt: ${{ env.REVIEW_PROMPT }}
+          # Bash(gh api:*) would be too broad here — a Codex finding caught
+          # that with pull-requests: write and issues: write on this job's
+          # token, an unrestricted `gh api` lets prompt-injected PR content
+          # hit ANY REST endpoint those scopes authorize (editing/closing
+          # unrelated PRs or issues, deleting review artifacts, etc.), not
+          # just posting this PR's own findings/verdict. Repo and PR number
+          # are concrete by the time this string is built, so the allowlist
+          # exposes only the two commit-bound review endpoints plus read-only
+          # local git diff. No tool can read mutable PR diff/view data.
+          claude_args: '--model ${{ steps.classify.outputs.model }} --allowedTools "Bash(git diff:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews:*)"'
+
+      - name: Check primary review actually succeeded
+        # The action can report GH Actions outcome=success while the
+        # underlying SDK call itself errored (e.g. instant quota-exhaustion
+        # failure) — outcome alone would silently miss that. Read the raw
+        # execution output the action always writes to confirm the run
+        # really finished cleanly.
+        id: review-check
+        if: always()
+        env:
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
+        run: |
+          OUT="$RUNNER_TEMP/claude-execution-output.json"
+          is_error="false"
+          if [ -f "$OUT" ]; then
+            is_error=$(jq -r '
+              if type != "array" then "false"
+              else ([.[] | select(.type == "result")] | if length > 0 then (.[-1].is_error // false | tostring) else "false" end)
+              end' "$OUT" 2>/dev/null || echo "false")
+          fi
+          if [ "$REVIEW_OUTCOME" = "failure" ] || [ "$is_error" = "true" ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Fallback retry on a SECOND token. An earlier revision of the donor
+      # workflow refused to do this, on a 2026-07-22 observation that
+      # CLAUDE_CODE_OAUTH_TOKEN and CLAUDE_CODE_OAUTH_TOKEN_2 failed
+      # identically ~16s apart and therefore had to share one org-wide quota.
+      # That generalisation was wrong: on 2026-08-03 the primary token was
+      # exhausted ("You're out of extra usage") while the fallback completed a
+      # full review on mctlhq/mctl-gitops#705 in the same minute.
+      - name: Reset git state before fallback
+        if: steps.review-check.outputs.failed == 'true' && steps.token-check.outputs.has_fallback == 'true'
+        run: git checkout . && git clean -fd
+
+      - name: Claude review (fallback token)
+        id: review2
+        if: steps.review-check.outputs.failed == 'true' && steps.token-check.outputs.has_fallback == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          allowed_bots: ${{ inputs.allowed-bots }}
+          track_progress: true
+          prompt: ${{ env.REVIEW_PROMPT }}
+          claude_args: '--model ${{ steps.classify.outputs.model }} --allowedTools "Bash(git diff:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews:*)"'
+
+      # The primary and the fallback write the same execution-output file, so
+      # re-read it here: after a fallback run it holds the FALLBACK result.
+      # If the fallback somehow exits without rewriting the file, this reads
+      # the primary's stale is_error=true and reports failure — deliberately
+      # fail-closed, since a green gate on an unverified review is the worse
+      # outcome.
+      - name: Check final review outcome
+        id: review-final
+        if: always()
+        env:
+          PRIMARY_FAILED: ${{ steps.review-check.outputs.failed }}
+          HAS_FALLBACK: ${{ steps.token-check.outputs.has_fallback }}
+          FALLBACK_OUTCOME: ${{ steps.review2.outcome }}
+        run: |
+          if [ "$PRIMARY_FAILED" != "true" ]; then
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          elif [ "$HAS_FALLBACK" != "true" ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          else
+            OUT="$RUNNER_TEMP/claude-execution-output.json"
+            is_error="false"
+            if [ -f "$OUT" ]; then
+              is_error=$(jq -r '
+                if type != "array" then "false"
+                else ([.[] | select(.type == "result")] | if length > 0 then (.[-1].is_error // false | tostring) else "false" end)
+                end' "$OUT" 2>/dev/null || echo "false")
+            fi
+            if [ "$FALLBACK_OUTCOME" = "failure" ] || [ "$is_error" = "true" ]; then
+              echo "failed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "failed=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Notify when no token could complete the review
+        if: steps.review-final.outputs.failed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "Claude review failed to complete on both tokens (see the [run log]($RUN_URL)). Re-trigger with \`@claude review\` once the underlying issue is resolved."
+
+      # Keep the notification above useful, but do not let continue-on-error
+      # turn a quota/auth/runtime failure into a green merge gate.
+      - name: Fail when Claude review did not complete
+        if: steps.review-final.outputs.failed == 'true'
+        run: |
+          echo "::error::Claude review did not complete"
+          exit 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,45 @@
+name: Claude PR review
+
+# This repository hosts the shared reviewer that 17 mctlhq repositories call,
+# so its own pull requests are worth reviewing too. Calls the reusable
+# workflow by local path rather than by SHA: for the self-hosting case a
+# pinned SHA would mean every edit to claude-review.yml also needs a bump
+# here, and the version under review is the one that should run.
+#
+# Note this cannot review a change to claude-review.yml or to this file:
+# claude-code-action refuses to run when the executing workflow differs from
+# the copy on the default branch ("Workflow validation failed"), which is
+# deliberate — otherwise a PR could rewrite the reviewer's own prompt and
+# allowlists and then be reviewed by the rewritten reviewer. Such PRs need a
+# human pass and an admin merge.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  claude-review:
+    uses: ./.github/workflows/claude-review.yml
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    with:
+      # Workflow definitions are the sensitive surface here: this file and the
+      # reusable it calls gate merges in every other repository.
+      sensitive-paths: '^\.github/workflows/'
+      conventions: |
+        This repository holds org-wide GitHub configuration: the shared
+        reusable review workflow and the organisation profile. There is no
+        application code. Weigh workflow correctness heavily — permission
+        scopes, secret handling, expression injection into `run:` blocks, and
+        anything that could let untrusted pull request content influence the
+        reviewer itself.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}


### PR DESCRIPTION
Step 1 of the alignment plan. **Nothing calls this workflow yet, so merging it changes no behaviour anywhere.**

## Why

`claude-review.yml` is copy-pasted across 17 mctlhq repositories. Audit on 2026-08-06:

| | mctl-telegram | other 16 |
|---|---|---|
| Structure | `gate` (read-only) → `review` | single `review` job (`claude-review` in openclaw) |
| Concurrency | SHA-scoped group | none |
| Immutable diff | `base_sha...head_sha`, `gh pr diff/view` forbidden | reads the live PR |
| Dedup + staleness | yes | no |
| Model | `claude-sonnet-5` | `claude-opus-4-7` / `claude-sonnet-4-6` |
| allowedTools | `git diff` + 2 commit-bound REST endpoints | `gh pr comment/review/diff/view` + MCP inline |

573 lines against 283. Every improvement to the reviewer currently costs 17 identical PRs, which is why none of the above was ever rolled out.

Two live bugs the audit surfaced, both fixed by adopting this file: `mctl-mcp` and `pfeifenpatenschaft-backend` omit `Bash(gh pr review:*)` from `allowedTools`, so their reviewer cannot submit a verdict at all; `pfeifenpatenschaft-backend` also has no `CLAUDE_CODE_OAUTH_TOKEN_2` fallback.

## What this is

mctl-telegram's version ported to `workflow_call`. Callers keep their own triggers and pin by SHA — see the usage block at the top of the file. SHA pinning is deliberate: `@main` would make one unreviewed edit change the merge gate in 17 repositories at once.

Repository-specific behaviour becomes inputs: `runner`, `model-high/mid/low`, `sensitive-paths` / `code-paths` / `test-paths`, `allowed-bots`, `conventions`. Defaults set the model tiers to `claude-sonnet-5` / `claude-haiku-4-5-20251001`.

## Deliberate changes from the donor

1. **The review prompt is defined once** as a job-level `env` value, referenced from both the primary and the fallback invocation. The donor wrote both copies inline — 90 duplicated lines that had to be kept identical by hand, with nothing to catch divergence.
2. **Values interpolated into shell scripts move to `env` bindings.** Caller-supplied regexes must never be spliced into a script body via `${{ }}`, where a pattern could terminate the surrounding quoting; repository, PR number and SHA get the same treatment for consistency.
3. **Secrets declared explicitly** instead of expecting callers to use `secrets: inherit`, which would hand every repository secret (`VAULT_TOKEN`, `APP_PRIVATE_KEY`) to a job that reads untrusted PR content.
4. **Classifier is language-agnostic** — the donor hardcoded `\.go$` and `^internal/(auth|crypto|db|mcp|telegram)/`; both are now inputs with sane defaults, since this file has to serve TypeScript, Python and YAML repositories too.

## Verification

- `actionlint` v1.7.12: clean. Verified it is actually checking this file by mutating `prompt:` to a bogus context and confirming it errors — so the `${{ env.REVIEW_PROMPT }}` reference inside `steps.*.with` is validated as legal, not merely unparsed.
- Classifier logic extracted and run locally against 8 cases (sensitive path, test-only, docs-only, plain source, docs + 500 lines, source + 500 lines, empty `sensitive-paths`, empty diff) — matches the donor's tiering.
- Re-run under `set -eo pipefail` (GitHub's default shell) to confirm the `[ "$score" -lt 2 ] && score=2` idiom does not abort the step when the test is false.

## Follow-up, not in this PR

`mctl-agents` has a ruleset requiring a status check literally named **`review`** — which is the claude-review job name. A reusable workflow reports as `<caller job> / <called job>` and can never produce a bare `review` context again, so that ruleset must be updated in the same window as its caller PR or its gate will block forever. `mctl-api` (`lint|test`), `mctl-web` (`build`) and `mctl-telegram` (`test, docker`) do not collide.

Rollout after this merges: pilot on one low-traffic repo, verify against a real PR, then the 11 unprotected repos, then the protected ones, with mctl-telegram last.

Note: `mctlhq/.github` has no workflows of its own, so this PR gets no automated review — it needs a human pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017srKGxpXvVYttoJVdcSKmk