### PR TITLE
ci(claude-review): add skip-paths input for content-only diffs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,6 +47,18 @@ on:
           only signals.
         type: string
         default: ''
+      skip-paths:
+        description: >
+          Extended regex matching paths that should never reach an LLM
+          reviewer at all (as opposed to sensitive-paths, which only picks a
+          model tier). When every changed file in the diff matches this
+          pattern, the review call is skipped entirely and the job succeeds
+          without posting a verdict. Intended for content that is already
+          gated by a deterministic pipeline plus human approval, where an LLM
+          review would just be checking another LLM's output. Empty disables
+          the check — nothing is ever skipped.
+        type: string
+        default: ''
       code-paths:
         description: >
           Extended regex matching non-test source files that warrant at least
@@ -410,6 +422,7 @@ jobs:
           # interpolated into the script body: `${{ }}` splicing would let a
           # caller's pattern terminate the surrounding quoting.
           SENSITIVE_PATHS: ${{ inputs.sensitive-paths }}
+          SKIP_PATHS: ${{ inputs.skip-paths }}
           CODE_PATHS: ${{ inputs.code-paths }}
           TEST_PATHS: ${{ inputs.test-paths }}
           MODEL_HIGH: ${{ inputs.model-high }}
@@ -421,6 +434,22 @@ jobs:
           files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
           lines=$(git diff --numstat "$BASE_SHA...$HEAD_SHA" |
             awk '{ if ($1 ~ /^[0-9]+$/) added += $1; if ($2 ~ /^[0-9]+$/) removed += $2 } END { print added + removed + 0 }')
+
+          # A diff entirely inside skip-paths never reaches the model at all —
+          # not even at the low tier. A single file outside the pattern is
+          # enough to cancel the skip, since that file still needs a real
+          # review regardless of how many skip-paths files ride along with it.
+          skip=false
+          if [ -n "$SKIP_PATHS" ]; then
+            skip=true
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              if ! printf '%s' "$f" | grep -qE "$SKIP_PATHS"; then
+                skip=false; break
+              fi
+            done <<< "$files"
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
           # Score: 3=high, 2=mid, 1=low
           score=1
@@ -484,7 +513,7 @@ jobs:
 
       - name: Claude review
         id: review
-        if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true'
+        if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true' && steps.classify.outputs.skip != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
         with:


### PR DESCRIPTION
## Summary
- Adds a `skip-paths` input to the reusable `claude-review.yml`: when every changed file in the diff matches this regex, the LLM review call is skipped entirely (not just downgraded to the low model tier like `sensitive-paths`/`code-paths` already do).
- Needed to migrate `mctl-academy` onto the shared reusable without a behavior regression: its content pipeline (`content/questions|lessons|sources/*`) is intentionally never sent to an LLM reviewer — it's gated by a deterministic evidence check + human approval, and an LLM reviewing another LLM's authored content is the exact loop that gate exists to avoid. `content/schemas/*` is excluded (still reviewed) since a bad schema silently weakens that gate.
- No change in behavior for any existing caller (`mctl-mcp` pilot) — `skip-paths` defaults to `''`, which disables the check entirely, same as `sensitive-paths`' empty default.

## Note
This PR touches `claude-review.yml` itself, so it cannot be auto-reviewed (self-skip guard covered in #7) — needs a human pass.

## Test plan
- [x] `python3 -c "yaml.safe_load(...)"` — parses
- [x] Standalone shell test of the skip predicate against 4 cases (all-skip, mixed, schemas-only, empty) — matches expected `skip` value in all 4
- [ ] Live verification once `mctl-academy` is migrated onto this SHA: a content-only PR gets no LLM review, a mixed PR still gets reviewed