### PR TITLE
fix(claude-review): bump claude-code-action pin to v1.0.189

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -515,7 +515,7 @@ jobs:
         id: review
         if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true' && steps.classify.outputs.skip != 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1.0.189
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: ${{ inputs.allowed-bots }}
@@ -572,7 +572,7 @@ jobs:
         id: review2
         if: steps.review-check.outputs.failed == 'true' && steps.token-check.outputs.has_fallback == 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1.0.189
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
           allowed_bots: ${{ inputs.allowed-bots }}


### PR DESCRIPTION
## Summary
- Bumps `anthropics/claude-code-action` pin from `@51ea8ea` (v1, bundles CLI 2.1.142) to `@6b082234` (v1.0.189, bundles CLI 2.1.226) in both the primary and fallback-token review steps.
- `model-high`/`model-mid`/`model-low` defaults are unchanged — they already point at `claude-sonnet-5` / `claude-haiku-4-5-20251001`, which are correct per the 2026-07-15 model unification.

## Why
mctlhq/mctl-academy PR #95's `claude-review` job failed instantly: the old pin's bundled CLI (2.1.142) predates local model-name validation for `claude-sonnet-5`, so the action rejected it before ever calling the API. This was a known, deferred risk from the 2026-07-15 model migration — CLI-side validation tightened upstream and finally tripped it. v1.0.189 bundles a CLI that recognizes `claude-sonnet-5` (confirmed against upstream test fixtures).

## Test plan
- [ ] Merge this PR
- [ ] Bump the caller pin SHA in each repo that consumes this reusable workflow (mctl-academy, mctl-agents, mctl-api, mctl-claude-remote, mctl-docs, mctl-gitops, mctl-telegram, mctl-web)
- [ ] Re-trigger `claude-review` on mctl-academy PR #95 and confirm it completes with a real verdict instead of instant-failing