### PR TITLE
ci: wire up agy review as a caller for dot-github-repo's own PRs

### DIFF
--- a/.github/workflows/agy-review-caller.yml
+++ b/.github/workflows/agy-review-caller.yml
@@ -1,0 +1,18 @@
+name: Agy PR review
+
+# Caller for this repo's own PRs, invoking the reusable definition in
+# agy-review.yml. Non-blocking: informational second opinion only, same as
+# the example documented at the top of that file.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  agy-review:
+    uses: ./.github/workflows/agy-review.yml
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary
- `agy-review.yml` in this repo is already a reusable `workflow_call` definition that other mctlhq repos invoke, but this repo never called it against its own PRs.
- Adds `agy-review-caller.yml`, a thin non-blocking caller pointing at the local reusable workflow — same pattern documented in the comment header of `agy-review.yml`.

## Why
Wanted a second opinion (agy, Gemini-based, separate quota pool from Claude) available on PRs to this repo, since `claude-review.yml`'s shared usage limit can leave a PR with no real review verdict (as happened on #12).

## Test plan
- [ ] Confirm the `agy-review` job fires on this PR via the `pull_request` trigger
- [ ] Confirm it posts a non-blocking informational comment