### PR TITLE
ci: let claude-review run on dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -87,7 +87,7 @@ on:
           Without an entry the action hard-fails with "Workflow initiated by
           non-human actor" on synchronize events from the mctl-agents pipeline.
         type: string
-        default: mctl-claude-remote,github-actions
+        default: mctl-claude-remote,github-actions,dependabot
       conventions:
         description: >
           Extra repository-specific guidance appended to the review prompt


### PR DESCRIPTION
Adds `dependabot` to `allowed-bots` so dependency PRs get an automatic
review instead of sitting unmergeable.

## Why

`claude-code-action` refuses to run when the PR was initiated by a bot that is
not on the list:

```
Action failed with error: Workflow initiated by non-human actor:
dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

Branch protection requires an approving review, so every dependabot PR was
structurally unmergeable — in mctl-telegram ten of them piled up over five days
and had to be unblocked by commenting `@claude review` on each one by hand.

## The other half of the fix

Bot-actor rejection was the *second* blocker. The first: workflow runs triggered
by Dependabot read a separate **Dependabot secret store**, not Actions secrets,
and mctlhq's was empty — so `CLAUDE_CODE_OAUTH_TOKEN` resolved to `""` and the
run reported "failed to complete on both tokens", which looks exactly like quota
exhaustion but never called the model. An org-level Dependabot secret was added
2026-08-13 19:42; the run right after it showed a non-empty token and failed on
the bot-actor check instead, which is what this PR fixes.

Note `CLAUDE_CODE_OAUTH_TOKEN_2` is not in the Dependabot store (secrets are
write-only, the existing value cannot be copied across), so dependabot runs have
no fallback token until it is pasted in.

## Risk

This lets PR content authored by a bot reach the reviewer prompt. For Dependabot
that content is generated by GitHub from the dependency's own release notes, not
by an arbitrary user, and the reviewer's tool allowlist is already restricted to
`git diff` and this PR's own comments/reviews endpoints.

## Note for merging

A PR that edits `claude-review.yml` cannot be reviewed by that same gate — the
action self-skips with "Workflow validation failed... must have identical content
to the default branch". Merge with `--admin`.
