### PR TITLE
ci: make the high tier real, and score Vue/mjs as code

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,9 +70,13 @@ on:
         type: string
         default: '\.(go|ts|tsx|mts|cts|js|jsx|mjs|cjs|vue|svelte|py|rs|java|rb|sh)$'
       test-paths:
-        description: Extended regex matching test files, excluded from code-paths.
+        description: >
+          Extended regex matching test files, excluded from code-paths. Keep
+          this in step with code-paths: an extension present in one and absent
+          from the other makes a test file score as production source, and
+          that composes with the size bump into a top-tier promotion.
         type: string
-        default: '(_test\.(go|py|rb)|\.(test|spec)\.(ts|tsx|js|jsx))$'
+        default: '(_test\.(go|py|rb)|\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs))$'
       size-exempt-paths:
         description: >
           Extended regex matching paths whose churn should not feed the
@@ -82,8 +86,13 @@ on:
           model-mid, but it bites now that the top tier is a costlier model.
           Only the size signal is affected — a lockfile still reaches the
           reviewer, and sensitive-paths and code-paths still see it.
+          Unlike the other path inputs, which are used with `grep -qE` (an
+          invalid pattern exits 2, reads as false, and the classifier carries
+          on), this one is evaluated by awk, where an invalid ERE is fatal and
+          fails the whole classify step. That is deliberate: silently counting
+          every lockfile would undo the input's only purpose.
         type: string
-        default: '(^|/)(pnpm-lock\.yaml|package-lock\.json|yarn\.lock|npm-shrinkwrap\.json|go\.sum|Cargo\.lock|uv\.lock|poetry\.lock|composer\.lock|Gemfile\.lock)$'
+        default: '(^|/)(pnpm-lock\.yaml|package-lock\.json|npm-shrinkwrap\.json|yarn\.lock|bun\.lock|go\.sum|go\.work\.sum|Cargo\.lock|uv\.lock|poetry\.lock|Pipfile\.lock|pdm\.lock|composer\.lock|Gemfile\.lock|gradle\.lockfile|flake\.lock|pubspec\.lock|\.terraform\.lock\.hcl)$|(^|/)__snapshots__/.*\.snap$'
       model-high:
         description: >
           Model for security-sensitive or large diffs. Must be more capable
@@ -454,12 +463,24 @@ jobs:
           # the live PR here: its head may move while this run is active.
           files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
           # Binary files report "-" for both counts, hence the numeric guards.
-          # $3 is the path; awk's ~ is ERE, the same dialect as grep -E, so a
-          # caller's size-exempt-paths behaves the same here as elsewhere.
+          #
+          # ENVIRON, not -v: POSIX processes a -v value as a string literal,
+          # so `\.` would be consumed before the regex engine sees it — gawk
+          # turns each one into an any-char `.` (with a warning per escape),
+          # mawk leaves it, and the pattern that runs depends on which awk the
+          # runner ships. ENVIRON skips that step and matches this job's
+          # convention of passing regexes as environment values.
+          #
+          # -F with a literal tab, not the default FS: awk's default splits on
+          # runs of spaces AND tabs, so `$3` would be the first word of a path
+          # containing a space. Renames arrive compacted as
+          # `old/{a => b}/pnpm-lock.yaml` in a single field; the anchors in
+          # size-exempt-paths are `(^|/)name$`, so the tail still matches.
           lines=$(git diff --numstat "$BASE_SHA...$HEAD_SHA" |
-            awk -v exempt="$SIZE_EXEMPT_PATHS" '
-              { if (exempt != "" && $3 ~ exempt) next
-                if ($1 ~ /^[0-9]+$/) added += $1
+            awk -F '\t' '
+              BEGIN { exempt = ENVIRON["SIZE_EXEMPT_PATHS"] }
+              exempt != "" && $3 ~ exempt { next }
+              { if ($1 ~ /^[0-9]+$/) added += $1
                 if ($2 ~ /^[0-9]+$/) removed += $2 }
               END { print added + removed + 0 }')
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,17 +62,37 @@ on:
       code-paths:
         description: >
           Extended regex matching non-test source files that warrant at least
-          the middle tier. Defaults to common compiled/scripting extensions.
+          the middle tier. Defaults to the extensions actually present in
+          mctlhq repositories. `.vue` and `.mjs` were missing until 2026-09-05,
+          which silently scored every single-file SFC change in mctl-web (36
+          .vue), mctl-design (29), mctl-academy (20 .vue, 53 .mjs) and
+          mctl-docs (7) at the docs tier.
         type: string
-        default: '\.(go|ts|tsx|js|jsx|py|rs|java|rb)$'
+        default: '\.(go|ts|tsx|mts|cts|js|jsx|mjs|cjs|vue|svelte|py|rs|java|rb|sh)$'
       test-paths:
         description: Extended regex matching test files, excluded from code-paths.
         type: string
         default: '(_test\.(go|py|rb)|\.(test|spec)\.(ts|tsx|js|jsx))$'
-      model-high:
-        description: Model for security-sensitive or large diffs.
+      size-exempt-paths:
+        description: >
+          Extended regex matching paths whose churn should not feed the
+          >400-line size bump. Generated lockfiles routinely move thousands of
+          lines for a one-line dependency change; counting them promoted such
+          diffs a tier on size alone. Harmless while model-high equalled
+          model-mid, but it bites now that the top tier is a costlier model.
+          Only the size signal is affected — a lockfile still reaches the
+          reviewer, and sensitive-paths and code-paths still see it.
         type: string
-        default: claude-sonnet-5
+        default: '(^|/)(pnpm-lock\.yaml|package-lock\.json|yarn\.lock|npm-shrinkwrap\.json|go\.sum|Cargo\.lock|uv\.lock|poetry\.lock|composer\.lock|Gemfile\.lock)$'
+      model-high:
+        description: >
+          Model for security-sensitive or large diffs. Must be more capable
+          than model-mid or sensitive-paths buys nothing: until 2026-09-05
+          both defaulted to claude-sonnet-5, so the eight repositories that
+          carefully enumerate their auth/crypto/db paths were getting the
+          middle tier's model on them.
+        type: string
+        default: claude-opus-5
       model-mid:
         description: Model for ordinary source changes.
         type: string
@@ -425,6 +445,7 @@ jobs:
           SKIP_PATHS: ${{ inputs.skip-paths }}
           CODE_PATHS: ${{ inputs.code-paths }}
           TEST_PATHS: ${{ inputs.test-paths }}
+          SIZE_EXEMPT_PATHS: ${{ inputs.size-exempt-paths }}
           MODEL_HIGH: ${{ inputs.model-high }}
           MODEL_MID: ${{ inputs.model-mid }}
           MODEL_LOW: ${{ inputs.model-low }}
@@ -432,8 +453,15 @@ jobs:
           # Read only the immutable commit pair captured by gate. Never query
           # the live PR here: its head may move while this run is active.
           files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          # Binary files report "-" for both counts, hence the numeric guards.
+          # $3 is the path; awk's ~ is ERE, the same dialect as grep -E, so a
+          # caller's size-exempt-paths behaves the same here as elsewhere.
           lines=$(git diff --numstat "$BASE_SHA...$HEAD_SHA" |
-            awk '{ if ($1 ~ /^[0-9]+$/) added += $1; if ($2 ~ /^[0-9]+$/) removed += $2 } END { print added + removed + 0 }')
+            awk -v exempt="$SIZE_EXEMPT_PATHS" '
+              { if (exempt != "" && $3 ~ exempt) next
+                if ($1 ~ /^[0-9]+$/) added += $1
+                if ($2 ~ /^[0-9]+$/) removed += $2 }
+              END { print added + removed + 0 }')
 
           # A diff entirely inside skip-paths never reaches the model at all —
           # not even at the low tier. A single file outside the pattern is

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,7 +76,7 @@ on:
           from the other makes a test file score as production source, and
           that composes with the size bump into a top-tier promotion.
         type: string
-        default: '(_test\.(go|py|rb)|\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs))$'
+        default: '((^|/)(test_[^/]+\.(py|sh)|[^/]+_spec\.rb)|_test\.(go|py|rb|sh)|\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|sh))$'
       size-exempt-paths:
         description: >
           Extended regex matching paths whose churn should not feed the
@@ -476,7 +476,11 @@ jobs:
           # containing a space. Renames arrive compacted as
           # `old/{a => b}/pnpm-lock.yaml` in a single field; the anchors in
           # size-exempt-paths are `(^|/)name$`, so the tail still matches.
-          lines=$(git diff --numstat "$BASE_SHA...$HEAD_SHA" |
+          # core.quotePath defaults to true, which C-quotes any path holding
+          # non-ASCII bytes and wraps it in literal double quotes — `$3` would
+          # then end in `"` and every $-anchored alternative in
+          # size-exempt-paths would miss.
+          lines=$(git -c core.quotePath=false diff --numstat "$BASE_SHA...$HEAD_SHA" |
             awk -F '\t' '
               BEGIN { exempt = ENVIRON["SIZE_EXEMPT_PATHS"] }
               exempt != "" && $3 ~ exempt { next }


### PR DESCRIPTION
The per-repo tiering mechanism already exists here — `sensitive-paths`,
`code-paths`/`test-paths`, `model-high`/`mid`/`low`. This PR does not add it. It
fixes three defects in the **defaults** that made it quieter than it looks.

## 1. `model-high` equalled `model-mid`

Both defaulted to `claude-sonnet-5`. Eight repositories pass `sensitive-paths`
and carefully enumerate their auth/crypto/db surfaces:

| repo | `sensitive-paths` |
|---|---|
| mctl-api, mctl-telegram | `^internal/(auth\|crypto\|db\|mcp\|telegram)/` |
| mctl-academy | `^(scripts/\|content/schemas/\|src/(db\|routes\|services\|auth)/\|\.github/workflows/)` |
| mctl-claude-remote | `^(entrypoint\.sh\|health-proxy\.js\|skills/pr-steward/)` |
| mctl-loyalty, mctl-pairdesk | `^src/(services\|routes\|db\|middleware\|telegram…)/` |
| mctl-openclaw | `^src/(secrets\|security\|pairing\|plugin-sdk)/` |
| pfeifenpatenschaft-backend | `^src/(reservations\|sweeper\|providers\|routes\|db\|pricing)` |

Scoring 3 instead of 2 selected the identical model string, so all of that
enumeration bought nothing. `model-high` now defaults to `claude-opus-5`.

## 2. `code-paths` omitted `.vue` and `.mjs`

The default `'\.(go|ts|tsx|js|jsx|py|rs|java|rb)$'` predates the Vue repos, and
**no caller overrides it**. Present in the org today: mctl-web 36 `.vue`,
mctl-design 29, mctl-academy 20 `.vue` + 53 `.mjs`, mctl-docs 7. A PR touching
only SFCs scored 1 and was reviewed by haiku unless a `.ts` file happened to
ride along or the diff crossed 400 lines.

Added `vue`, `svelte`, `mjs`, `cjs`, `mts`, `cts`, `sh`.

## 3. The size bump counted lockfiles

`lines` came from `git diff --numstat` over every path, so a one-line dependency
change moved thousands of lines of `pnpm-lock.yaml` and promoted the diff a tier
on churn alone. Harmless while high equalled mid — with (1) it would send every
dependabot PR in fifteen repositories to Opus.

New `size-exempt-paths` input (default: the usual lockfiles) drops them from the
**line count only**. A lockfile still reaches the reviewer, and `sensitive-paths`
and `code-paths` still see it.

## Verification

Both variants scored over the changed cases and their regressions:

```
MButton.vue (single SFC)        old=1 new=2
build-mock-bundle.mjs           old=1 new=2
deploy.sh                       old=1 new=2
handler.go                      old=2 new=2   (regression check)
README.md                       old=1 new=1
h_test.go                       old=1 new=1   (test still excluded)

dependabot bump (pkg.json 3 + lock 3000):  before=3003 lines  after=3
genuine 550-line change + a binary file:   after=550 lines
```

## Cost

Only (1) increases spend, and only on paths a repository explicitly declared
sensitive, or on genuinely large diffs. Opus 5 is \$5/\$25 per MTok against
Sonnet 5's \$2/\$10. (3) removes the largest accidental source of top-tier
promotion in the same change, so for dependency-bump traffic the net direction
is down.

## Note on merging this one

`pr-review.yml` in this repository calls the reusable workflow by local path and
already documents the consequence: a PR that edits `claude-review.yml` cannot be
reviewed by it, because `claude-code-action` refuses to run when the executing
workflow differs from the copy on the default branch. That is deliberate.
Needs a human pass and an `--admin` merge.

Callers pin this workflow by SHA, so nothing changes for any repository until
its pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019edPKN51wYCwzMHj22Vwcz