### PR TITLE
ci: close quotePath on --name-only too, and __tests__/

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,7 +76,7 @@ on:
           from the other makes a test file score as production source, and
           that composes with the size bump into a top-tier promotion.
         type: string
-        default: '((^|/)(test_[^/]+\.(py|sh)|[^/]+_spec\.rb)|_test\.(go|py|rb|sh)|\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|sh))$'
+        default: '((^|/)__tests__/.+|(^|/)(test_[^/]+\.(py|sh)|[^/]+_spec\.rb|conftest\.py)|_test\.(go|py|rb|sh)|\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|sh))$'
       size-exempt-paths:
         description: >
           Extended regex matching paths whose churn should not feed the
@@ -461,7 +461,12 @@ jobs:
         run: |
           # Read only the immutable commit pair captured by gate. Never query
           # the live PR here: its head may move while this run is active.
-          files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          # core.quotePath=false on both calls: it defaults to true for every
+          # path-printing command, and a C-quoted path breaks the anchors in
+          # opposite directions. Here the leading `"` defeats the `^` in every
+          # caller's sensitive-paths, so a declared-sensitive file with one
+          # non-ASCII byte silently drops out of the top tier.
+          files=$(git -c core.quotePath=false diff --name-only "$BASE_SHA...$HEAD_SHA")
           # Binary files report "-" for both counts, hence the numeric guards.
           #
           # ENVIRON, not -v: POSIX processes a -v value as a string literal,
@@ -471,9 +476,13 @@ jobs:
           # runner ships. ENVIRON skips that step and matches this job's
           # convention of passing regexes as environment values.
           #
-          # -F with a literal tab, not the default FS: awk's default splits on
-          # runs of spaces AND tabs, so `$3` would be the first word of a path
-          # containing a space. Renames arrive compacted as
+          # -F '\t', not the default FS: awk's default splits on runs of
+          # spaces AND tabs, so `$3` would be the first word of a path
+          # containing a space. Note this is a two-character string, not a
+          # literal tab — POSIX handles the -F operand as if it were
+          # `-v FS=value`, so the very escape processing the paragraph above
+          # avoids for the pattern is what turns `\t` into TAB here. gawk,
+          # mawk and busybox awk all agree on `\t`, so it is portable. Renames arrive compacted as
           # `old/{a => b}/pnpm-lock.yaml` in a single field; the anchors in
           # size-exempt-paths are `(^|/)name$`, so the tail still matches.
           # core.quotePath defaults to true, which C-quotes any path holding


### PR DESCRIPTION
Follow-up to #24, which merged at `daa208f5` while this commit was in flight —
it is the third review round's fixes, and one of them matters.

## The one that matters

`#24`'s second commit says in its subject that it closes the `core.quotePath`
case. It closed the `--numstat` half only. `--name-only` — the call whose output
the scoring loop iterates — was left quoting, and there the failure direction is
**down-tier**:

```
"internal/auth/\320\272\320\273\321\216\321\207.go"
```

The leading `"` defeats the `^` that all eight callers' `sensitive-paths` begin
with (`^internal/(auth|crypto|db|…)/`, `^(scripts/|content/schemas/|…)`, …), so a
file a repository explicitly declared sensitive drops out of the top tier as
soon as one non-ASCII byte appears anywhere in its path. `code-paths` is
`$`-anchored and misses the same way, scoring 1 instead of 2. `skip-paths`
misses too, which only over-reviews and is harmless.

This is #24's first defect — a declared top tier that does not fire — coming
back through the door, on precisely the paths those repositories took the
trouble to enumerate. Both git calls now carry `-c core.quotePath=false`.

**Currently on `main`**, so worth landing before any caller bumps its pin.

## Two smaller ones

- The comment claimed `-F "\t"` is "a literal tab". It is not: POSIX handles the
  `-F` operand as if it were `-v FS=value`, so the escape processing the
  paragraph six lines above tells the reader to avoid is exactly what turns
  `\t` into TAB. The code is correct and portable (gawk, mawk and busybox awk
  all agree); the file was teaching two rules that contradict each other.
- `test-paths` gains `(^|/)__tests__/.+` and `conftest.py`. Jest and Vitest
  resolve everything under `__tests__/` as a test with no infix required, so
  `__tests__/Button.tsx`, `__tests__/helpers.ts` and `__tests__/setup.mjs` were
  scoring as production source. `__snapshots__` went into `size-exempt-paths`
  in #24 and only ever sits beside a `__tests__` directory — the repositories
  that motivated the one entry are the ones that hit the other.

## Verification

Everything under `__tests__/` plus `conftest.py` scores 1, while `app.mjs`,
`MBtn.vue`, `deploy.sh` and `src/tests.ts` stay 2 — the last confirming
`__tests__` does not match a bare `tests` component. Nothing that scored 1
before moved. A quoted `"internal/auth/\320\272…\.go"` no longer reaches the
matcher at all now that both git calls disable quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019edPKN51wYCwzMHj22Vwcz