### PR TITLE
ci: raise the low tier to sonnet-5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -107,9 +107,15 @@ on:
         type: string
         default: claude-sonnet-5
       model-low:
-        description: Model for docs/config-only diffs.
+        description: >
+          Model for docs/config-only diffs. Not a cheaper reviewer any more:
+          on 2026-09-05 mctl-gitops#1058 classified score=1 and APPROVED the
+          same docs-only diff twice on claude-haiku-4-5-20251001, while the
+          Gemini reviewer found a real P2 on both passes. The tier still
+          exists because the classifier's `skip` output is what `skip-paths`
+          rides on, but the model no longer drops below model-mid.
         type: string
-        default: claude-haiku-4-5-20251001
+        default: claude-sonnet-5
       allowed-bots:
         description: >
           Comma-separated bot actors whose pushes may still be reviewed.


### PR DESCRIPTION
`model-low` was the only tier still on `claude-haiku-4-5-20251001`, and it is the tier that reviews documentation and configuration — including the platform skills other agents follow verbatim.

**Evidence it is too little model.** `mctl-gitops#1058` was a docs-only diff, classified `score=1` on both passes, and haiku returned APPROVED both times. The Gemini reviewer found a real P2 on each of those same two passes:

- the skill's step 2 ("don't edit unimported files") contradicted its reworded step 5 ("no stale strings anywhere"), so a future dead file would wedge the run;
- the reverse-import grep it prescribes misclassifies entrypoints and tests as dead code, because nothing imports those by design.

Neither is subtle, and both would have shipped.

With `model-high` now `claude-opus-5` (#24), the three tiers collapse into two real choices: opus-5 for sensitive or large diffs, sonnet-5 for everything else.

**The classify step stays.** It is not only model selection — it also emits the `skip` output that `skip-paths` rides on (mctl-academy is the current consumer), and it is what routes a diff to the high tier at all. Removing it would silently un-skip those paths.

No caller overrides `model-low`, so this reaches all 16 repositories on the next SHA bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gKNZMR9nTRY2HwebYRUJG