### PR TITLE
ci: surface the self-edit review refusal instead of going green

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -617,40 +617,70 @@ jobs:
         run: |
           set -euo pipefail
 
-          path=${WORKFLOW_REF%@*}
+          # Split on the first `@refs/` rather than the last `@`:
+          # `github.workflow_ref` always fully qualifies the ref half, and git
+          # permits `@` inside a branch name, so `refs/heads/feat@2` would
+          # otherwise leave the ref's prefix stuck on the path.
+          path=${WORKFLOW_REF%%@refs/*}
           path=${path#"$REPO/"}
+          wf_ref=refs/${WORKFLOW_REF#*@refs/}
+          case "$path" in
+            .github/workflows/*) ;;
+            *)
+              echo "::warning::unrecognised workflow_ref '$WORKFLOW_REF' — skipping the self-edit check"
+              echo "blocked=false" >> "$GITHUB_OUTPUT"
+              exit 0 ;;
+          esac
 
           # Compare the file at the ref the run actually loaded it from, not
           # at the PR head. On `issue_comment` GitHub runs the DEFAULT-branch
           # copy of the workflow, so a self-edit PR re-triggered with
           # `@claude review` is reviewed normally — comparing the head there
-          # would refuse a run that the action is perfectly happy to perform.
-          wf_ref=${WORKFLOW_REF##*@}
-          case "$path" in
-            .github/workflows/*) ;;
-            *)
-              echo "::notice::unrecognised workflow_ref '$WORKFLOW_REF' — skipping the self-edit check"
-              echo "blocked=false" >> "$GITHUB_OUTPUT"
-              exit 0 ;;
-          esac
-
-          default_branch=$(gh api "repos/$REPO" -q .default_branch)
+          # would refuse a run the action is perfectly happy to perform. That
+          # is also why the comment below names `@claude review` as the way
+          # out: it is the one trigger whose entry file passes validation.
+          #
+          # Every read below fails OPEN, and says so at warning level. An
+          # unreachable API means "cannot predict", not "refuse" — a red
+          # check with nothing on the board is the same unexplained state
+          # this step exists to remove, only inverted. Warning rather than
+          # notice because `blocked=true` is reachable only through these
+          # calls: if they start failing, a permanently no-op check would
+          # otherwise be indistinguishable from a healthy one.
+          if ! default_branch=$(gh api "repos/$REPO" -q .default_branch 2>/dev/null); then
+            echo "::warning::could not read the default branch — skipping the self-edit check"
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # A blob SHA is content-addressed, so comparing the two is exactly
           # the "identical content" test the action performs, without pulling
-          # either file down.
-          head_blob=$(gh api "repos/$REPO/contents/$path?ref=$wf_ref" -q .sha 2>/dev/null || echo "")
-          base_blob=$(gh api "repos/$REPO/contents/$path?ref=$default_branch" -q .sha 2>/dev/null || echo "")
-
-          if [ -z "$head_blob" ]; then
-            # Nothing to compare against; let the action speak for itself.
-            echo "::notice::could not read $path at $wf_ref — skipping the self-edit check"
+          # either file down. `?ref=refs/pull/<n>/merge` resolves — verified
+          # against this PR's own merge ref before merge.
+          if ! head_blob=$(gh api "repos/$REPO/contents/$path?ref=$wf_ref" -q .sha 2>/dev/null); then
+            echo "::warning::could not read $path at $wf_ref — skipping the self-edit check"
             echo "blocked=false" >> "$GITHUB_OUTPUT"
-          elif [ "$head_blob" = "$base_blob" ]; then
+            exit 0
+          fi
+
+          # 404 is meaningful here and must not be lumped in with a blip: a
+          # workflow file absent from the default branch is refused by the
+          # action for the same reason an edited one is. Any other error is a
+          # transient read, and treating it as absence would post the notice
+          # below on a PR that touches no workflow at all.
+          if ! base_blob=$(gh api "repos/$REPO/contents/$path?ref=$default_branch" -q .sha 2>base.err); then
+            if grep -q "HTTP 404" base.err; then
+              base_blob=""
+            else
+              echo "::warning::could not read $path at $default_branch — skipping the self-edit check"
+              echo "blocked=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          if [ "$head_blob" = "$base_blob" ]; then
             echo "blocked=false" >> "$GITHUB_OUTPUT"
           else
-            # Covers both an edit and a brand-new workflow file absent from the
-            # default branch, which the action refuses for the same reason.
             echo "::warning::$path differs from $default_branch — claude-code-action will refuse to run on this PR."
             echo "blocked=true" >> "$GITHUB_OUTPUT"
             echo "path=$path" >> "$GITHUB_OUTPUT"
@@ -687,7 +717,9 @@ jobs:
                 "\`claude[bot]\` will not leave an approving review. Nothing is wrong with" \
                 "the change itself." \
                 "" \
-                "Review resumes by itself on the next pull request, once this one is merged.")
+                "To get a verdict on this commit, comment \`@claude review\` here. That run" \
+                "loads the workflow from the default branch instead of from this branch, so" \
+                "the action accepts it and reviews normally.")
               gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" ;;
           esac
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -586,9 +586,119 @@ jobs:
             echo "has_fallback=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # claude-code-action refuses to run when the workflow file that invoked
+      # it differs from the copy on the default branch: "Workflow validation
+      # failed. The workflow file must exist and have identical content to the
+      # version on the repository's default branch." That is a deliberate
+      # security property — otherwise a pull request could rewrite its own
+      # reviewer — and it fires on any edit to the CALLER, including a
+      # one-line bump of the `uses:` pin below.
+      #
+      # Left alone, the refusal is invisible in exactly the way that matters.
+      # The action emits a ::warning:: and exits with outcome=success, the
+      # steps downstream see no error to read, and the job goes green having
+      # reviewed nothing and approved nothing. On a repository whose merge gate
+      # is an approving review rather than a status check, that leaves an
+      # unmergeable pull request with a fully green board and no stated reason
+      # (mctlhq/mctl-gitops#1060).
+      #
+      # So predict the refusal instead of discovering it: compare the blob the
+      # action will compare. This is deterministic, costs two API reads, and
+      # needs no log scraping.
+      - name: Detect entry-workflow self-edit
+        id: selfedit
+        if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true' && steps.classify.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Inside a reusable workflow this names the ENTRY workflow — the
+          # caller's file, which is the one the action validates — not this
+          # file. Shape: owner/repo/.github/workflows/name.yml@refs/heads/main
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          set -euo pipefail
+
+          path=${WORKFLOW_REF%@*}
+          path=${path#"$REPO/"}
+
+          # Compare the file at the ref the run actually loaded it from, not
+          # at the PR head. On `issue_comment` GitHub runs the DEFAULT-branch
+          # copy of the workflow, so a self-edit PR re-triggered with
+          # `@claude review` is reviewed normally — comparing the head there
+          # would refuse a run that the action is perfectly happy to perform.
+          wf_ref=${WORKFLOW_REF##*@}
+          case "$path" in
+            .github/workflows/*) ;;
+            *)
+              echo "::notice::unrecognised workflow_ref '$WORKFLOW_REF' — skipping the self-edit check"
+              echo "blocked=false" >> "$GITHUB_OUTPUT"
+              exit 0 ;;
+          esac
+
+          default_branch=$(gh api "repos/$REPO" -q .default_branch)
+
+          # A blob SHA is content-addressed, so comparing the two is exactly
+          # the "identical content" test the action performs, without pulling
+          # either file down.
+          head_blob=$(gh api "repos/$REPO/contents/$path?ref=$wf_ref" -q .sha 2>/dev/null || echo "")
+          base_blob=$(gh api "repos/$REPO/contents/$path?ref=$default_branch" -q .sha 2>/dev/null || echo "")
+
+          if [ -z "$head_blob" ]; then
+            # Nothing to compare against; let the action speak for itself.
+            echo "::notice::could not read $path at $wf_ref — skipping the self-edit check"
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          elif [ "$head_blob" = "$base_blob" ]; then
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          else
+            # Covers both an edit and a brand-new workflow file absent from the
+            # default branch, which the action refuses for the same reason.
+            echo "::warning::$path differs from $default_branch — claude-code-action will refuse to run on this PR."
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            echo "path=$path" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Say it once per commit, on the pull request, where the person waiting
+      # for a verdict is looking. The marker carries the head SHA so a later
+      # push gets a fresh notice instead of being silently covered by an old
+      # one, and so tooling can recognise this state without parsing prose.
+      - name: Explain the self-edit refusal
+        if: steps.selfedit.outputs.blocked == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WF_PATH: ${{ steps.selfedit.outputs.path }}
+        run: |
+          set -euo pipefail
+
+          marker="<!-- claude-review:self-edit:$HEAD_SHA -->"
+
+          # Matched with a case glob rather than `grep -qF`: under pipefail a
+          # `grep -q` that exits on its first match can SIGPIPE the producer
+          # and turn a HIT into a non-zero pipeline, which would read here as
+          # "not announced yet" and comment again on every re-run.
+          existing=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" --jq '.[].body' || true)
+          case "$existing" in
+            *"$marker"*)
+              echo "already announced for $HEAD_SHA" ;;
+            *)
+              body=$(printf '%s\n' \
+                "$marker" \
+                "This pull request edits \`$WF_PATH\`, the workflow file that invokes the" \
+                "reviewer. \`claude-code-action\` runs only when that file is identical to" \
+                "the copy on the default branch, so it will not review this commit and" \
+                "\`claude[bot]\` will not leave an approving review. Nothing is wrong with" \
+                "the change itself." \
+                "" \
+                "Review resumes by itself on the next pull request, once this one is merged.")
+              gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" ;;
+          esac
+
+          # Fail closed. Green here would read as "reviewed, found nothing",
+          # which is the one thing that did not happen.
+          echo "::error::No review ran — this PR edits the workflow that invokes the reviewer."
+          exit 1
+
       - name: Claude review
         id: review
-        if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true' && steps.classify.outputs.skip != 'true'
+        if: steps.dedup.outputs.already_reviewed != 'true' && steps.prerun-staleness.outputs.stale != 'true' && steps.classify.outputs.skip != 'true' && steps.selfedit.outputs.blocked != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1.0.189 (CLI 2.1.226)
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -689,6 +689,13 @@ jobs:
               echo "blocked=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+          elif [ "$base_blob" = "null" ]; then
+            # Same "null" hazard as the two reads above, and the loudest of
+            # the three: a literal "null" here compares unequal to a real
+            # head blob and would report a self-edit on a PR that has none.
+            echo "::warning::unusable response for $path at $default_branch — skipping the self-edit check"
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # Absent and differing both make the action refuse, but they are not
@@ -740,8 +747,8 @@ jobs:
               "" \
               "There is no way to get a verdict on this pull request — \`@claude review\`" \
               "will not help either, because the trigger it needs is in the file being" \
-              "added. Reviews begin with the next pull request, once this one has landed" \
-              "on the default branch.")
+              "added. This check will stay red on every commit here; merge past it, and" \
+              "reviews begin with the next pull request.")
           else
             body=$(printf '%s\n' \
               "$marker" \
@@ -756,6 +763,18 @@ jobs:
               "the action accepts it and reviews normally.")
           fi
 
+          # Annotate BEFORE reaching for the API. Under `set -e` a failing
+          # `gh pr comment` aborts the step, and if the annotation came after
+          # it, that one failure would cost both — leaving the red check with
+          # nothing on it, which is the state this whole step exists to
+          # prevent. The annotation is the half that cannot fail.
+          if [ "$REASON" = "absent" ]; then
+            why="is not on the default branch yet"
+          else
+            why="differs from the copy on the default branch"
+          fi
+          echo "::error::No review ran — $WF_PATH $why, so the reviewer refused to start."
+
           # Matched with a case glob rather than `grep -qF`: under pipefail a
           # `grep -q` that exits on its first match can SIGPIPE the producer
           # and turn a HIT into a non-zero pipeline, which would read here as
@@ -768,12 +787,6 @@ jobs:
 
           # Fail closed. Green here would read as "reviewed, found nothing",
           # which is the one thing that did not happen.
-          if [ "$REASON" = "absent" ]; then
-            why="is not on the default branch yet"
-          else
-            why="differs from the copy on the default branch"
-          fi
-          echo "::error::No review ran — $WF_PATH $why, so the reviewer refused to start."
           exit 1
 
       - name: Claude review

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -647,7 +647,12 @@ jobs:
           # notice because `blocked=true` is reachable only through these
           # calls: if they start failing, a permanently no-op check would
           # otherwise be indistinguishable from a healthy one.
-          if ! default_branch=$(gh api "repos/$REPO" -q .default_branch 2>/dev/null); then
+          # `-q` on a missing key yields the string "null" with a zero exit,
+          # so an exit-status guard alone is not total: `?ref=null` would 404,
+          # read as "absent from the default branch", and produce a false red
+          # on a PR that touches no workflow.
+          default_branch=$(gh api "repos/$REPO" -q .default_branch 2>/dev/null || echo "")
+          if [ -z "$default_branch" ] || [ "$default_branch" = "null" ]; then
             echo "::warning::could not read the default branch — skipping the self-edit check"
             echo "blocked=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -657,7 +662,8 @@ jobs:
           # the "identical content" test the action performs, without pulling
           # either file down. `?ref=refs/pull/<n>/merge` resolves — verified
           # against this PR's own merge ref before merge.
-          if ! head_blob=$(gh api "repos/$REPO/contents/$path?ref=$wf_ref" -q .sha 2>/dev/null); then
+          head_blob=$(gh api "repos/$REPO/contents/$path?ref=$wf_ref" -q .sha 2>/dev/null || echo "")
+          if [ -z "$head_blob" ] || [ "$head_blob" = "null" ]; then
             echo "::warning::could not read $path at $wf_ref — skipping the self-edit check"
             echo "blocked=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -668,8 +674,15 @@ jobs:
           # action for the same reason an edited one is. Any other error is a
           # transient read, and treating it as absence would post the notice
           # below on a PR that touches no workflow at all.
-          if ! base_blob=$(gh api "repos/$REPO/contents/$path?ref=$default_branch" -q .sha 2>base.err); then
-            if grep -q "HTTP 404" base.err; then
+          # Written under RUNNER_TEMP: the workspace is the tree the reviewer
+          # reads, and a stray file there would show up in its `git status`.
+          #
+          # Matching on gh's stderr wording couples this to the CLI's
+          # phrasing. It fails in the safe direction — a reworded 404 reads
+          # as transient and skips the check — but it is worth knowing about.
+          err="$RUNNER_TEMP/base.err"
+          if ! base_blob=$(gh api "repos/$REPO/contents/$path?ref=$default_branch" -q .sha 2>"$err"); then
+            if grep -q "HTTP 404" "$err"; then
               base_blob=""
             else
               echo "::warning::could not read $path at $default_branch — skipping the self-edit check"
@@ -678,12 +691,21 @@ jobs:
             fi
           fi
 
+          # Absent and differing both make the action refuse, but they are not
+          # the same situation for the person reading the result, and only one
+          # of them has a way out. Carry the distinction into the output.
           if [ "$head_blob" = "$base_blob" ]; then
             echo "blocked=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::$path differs from $default_branch — claude-code-action will refuse to run on this PR."
             echo "blocked=true" >> "$GITHUB_OUTPUT"
             echo "path=$path" >> "$GITHUB_OUTPUT"
+            if [ -z "$base_blob" ]; then
+              echo "::warning::$path does not exist on $default_branch — claude-code-action will refuse to run on this PR."
+              echo "reason=absent" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::$path differs from $default_branch — claude-code-action will refuse to run on this PR."
+              echo "reason=differs" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       # Say it once per commit, on the pull request, where the person waiting
@@ -695,10 +717,44 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           WF_PATH: ${{ steps.selfedit.outputs.path }}
+          REASON: ${{ steps.selfedit.outputs.reason }}
         run: |
           set -euo pipefail
 
           marker="<!-- claude-review:self-edit:$HEAD_SHA -->"
+
+          # `@claude review` is the way out of an EDIT, because
+          # `issue_comment` runs the default-branch copy of the workflow. That
+          # is exactly why it is not the way out of an ABSENCE: on the PR that
+          # ADDS the workflow, the trigger lives in the file being added and
+          # so is not on the default branch, and nothing would fire at all. An
+          # instruction that silently does nothing is worse than saying
+          # plainly that there is no verdict to be had here.
+          if [ "$REASON" = "absent" ]; then
+            body=$(printf '%s\n' \
+              "$marker" \
+              "This pull request adds \`$WF_PATH\`, the workflow file that invokes the" \
+              "reviewer. \`claude-code-action\` runs only when that file already exists on" \
+              "the default branch and matches it, so it cannot review the commit that" \
+              "introduces it. Nothing is wrong with the change itself." \
+              "" \
+              "There is no way to get a verdict on this pull request — \`@claude review\`" \
+              "will not help either, because the trigger it needs is in the file being" \
+              "added. Reviews begin with the next pull request, once this one has landed" \
+              "on the default branch.")
+          else
+            body=$(printf '%s\n' \
+              "$marker" \
+              "This pull request edits \`$WF_PATH\`, the workflow file that invokes the" \
+              "reviewer. \`claude-code-action\` runs only when that file is identical to" \
+              "the copy on the default branch, so it will not review this commit and" \
+              "\`claude[bot]\` will not leave an approving review. Nothing is wrong with" \
+              "the change itself." \
+              "" \
+              "To get a verdict on this commit, comment \`@claude review\` here. That run" \
+              "loads the workflow from the default branch instead of from this branch, so" \
+              "the action accepts it and reviews normally.")
+          fi
 
           # Matched with a case glob rather than `grep -qF`: under pipefail a
           # `grep -q` that exits on its first match can SIGPIPE the producer
@@ -706,26 +762,18 @@ jobs:
           # "not announced yet" and comment again on every re-run.
           existing=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" --jq '.[].body' || true)
           case "$existing" in
-            *"$marker"*)
-              echo "already announced for $HEAD_SHA" ;;
-            *)
-              body=$(printf '%s\n' \
-                "$marker" \
-                "This pull request edits \`$WF_PATH\`, the workflow file that invokes the" \
-                "reviewer. \`claude-code-action\` runs only when that file is identical to" \
-                "the copy on the default branch, so it will not review this commit and" \
-                "\`claude[bot]\` will not leave an approving review. Nothing is wrong with" \
-                "the change itself." \
-                "" \
-                "To get a verdict on this commit, comment \`@claude review\` here. That run" \
-                "loads the workflow from the default branch instead of from this branch, so" \
-                "the action accepts it and reviews normally.")
-              gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" ;;
+            *"$marker"*) echo "already announced for $HEAD_SHA" ;;
+            *) gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" ;;
           esac
 
           # Fail closed. Green here would read as "reviewed, found nothing",
           # which is the one thing that did not happen.
-          echo "::error::No review ran — this PR edits the workflow that invokes the reviewer."
+          if [ "$REASON" = "absent" ]; then
+            why="is not on the default branch yet"
+          else
+            why="differs from the copy on the default branch"
+          fi
+          echo "::error::No review ran — $WF_PATH $why, so the reviewer refused to start."
           exit 1
 
       - name: Claude review


### PR DESCRIPTION
## Problem

`claude-code-action` refuses to run when the workflow file that invoked it
differs from the copy on the default branch:

```
##[warning]Skipping action due to workflow validation: Workflow validation
failed. The workflow file must exist and have identical content to the
version on the repository's default branch.
...
##[end-action id=review.run;outcome=success;conclusion=success]
```

The refusal itself is correct and deliberate — otherwise a pull request could
rewrite its own reviewer. What is wrong is that it is invisible. The action
exits with `outcome=success` and writes no execution output, so `Check primary
review actually succeeded` reads `is_error=false`, the fallback token is never
tried, and `claude-review / review` reports **SUCCESS** having reviewed nothing
and approved nothing.

On a repository gated by an approving review rather than by status checks, that
leaves an unmergeable pull request with a fully green board and no stated reason
anywhere — not in a check, not in a comment. `mctlhq/mctl-gitops#1060`, a
two-line bump of this workflow's own pin, was diagnosed as a quota problem, then
a tiering problem, then a ruleset problem, before the run log produced the
warning above.

## Fix

Predict the refusal instead of discovering it. `Detect entry-workflow self-edit`
compares the blob SHA of the entry workflow at the ref the run actually loaded
it from against the copy on the default branch. A blob SHA is
content-addressed, so this is exactly the "identical content" test the action
performs; it costs two API reads and needs no log scraping.

When they differ:

- the review call is skipped rather than left to fail silently;
- one comment is posted per commit, carrying
  `<!-- claude-review:self-edit:<sha> -->` so a later push gets a fresh notice
  and tooling can recognise the state without parsing prose;
- the job **fails**. Green here would read as "reviewed, found nothing", which
  is the one thing that did not happen.

Two details worth reviewing closely:

- The comparison uses the ref from `github.workflow_ref`, **not** the PR head.
  On `issue_comment` GitHub runs the default-branch copy of the workflow, so a
  self-edit PR re-triggered with `@claude review` is reviewed normally —
  comparing the head there would refuse a run the action is happy to perform.
- The marker lookup uses a `case` glob, not `grep -qF`. Under `pipefail` a
  `grep -q` that exits on its first match can SIGPIPE `gh api --paginate` and
  turn a hit into a non-zero pipeline, which would read as "not announced yet"
  and comment again on every re-run.

## Test plan

- [ ] This PR: unchanged behaviour, since it edits the reusable workflow and not
      any caller's entry file — `pr-review.yml` reviews it normally.
- [ ] A follow-up PR in a caller repository that edits its own
      `claude-review.yml`: expect `claude-review / review` **FAILURE** with the
      explanatory comment, where today it is green and silent.

## Not in this change

`Check primary review actually succeeded` still treats a missing
`claude-execution-output.json` as success. Failing closed on the missing file
would be a broader net, but it rests on an invariant I cannot verify from
outside the action — that a healthy run always writes it — and getting that
wrong turns every review red in fifteen repositories. Left deliberately, to be
decided separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019edPKN51wYCwzMHj22Vwcz
