### PR TITLE
fix(ci): preserve runner auth when agy secret is absent

### DIFF
--- a/.github/workflows/agy-review.yml
+++ b/.github/workflows/agy-review.yml
@@ -197,10 +197,18 @@ jobs:
         shell: bash
         working-directory: ${{ env.AGY_SCRATCH }}
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || secrets.AGY_API_KEY }}
+          AGY_SECRET: ${{ secrets.GEMINI_API_KEY || secrets.AGY_API_KEY }}
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$PATH"
+          if [ -n "${AGY_SECRET:-}" ]; then
+            export GEMINI_API_KEY="$AGY_SECRET"
+            echo "Using secret-backed agy authentication."
+          else
+            unset GEMINI_API_KEY
+            echo "No agy API secret supplied; using runner-local/default authentication."
+          fi
+
           agy \
             -p "$(cat prompt.md)" \
             --model "${{ inputs.model }}" \

--- a/.github/workflows/agy-review.yml
+++ b/.github/workflows/agy-review.yml
@@ -204,9 +204,11 @@ jobs:
           if [ -n "${AGY_SECRET:-}" ]; then
             export GEMINI_API_KEY="$AGY_SECRET"
             echo "Using secret-backed agy authentication."
-          else
+          elif [ -z "${GEMINI_API_KEY:-}" ]; then
             unset GEMINI_API_KEY
             echo "No agy API secret supplied; using runner-local/default authentication."
+          else
+            echo "Using runner-supplied GEMINI_API_KEY."
           fi
 
           agy \


### PR DESCRIPTION
## Summary

Fixes the reusable Agy reviewer so an absent GitHub secret does not force `GEMINI_API_KEY` to an empty string and shadow the self-hosted runner's local/default authentication path.

- move the optional secret into an inert `AGY_SECRET` variable;
- export `GEMINI_API_KEY` only when a non-empty secret is actually present;
- otherwise explicitly unset `GEMINI_API_KEY` and let `agy` use runner-local/default auth;
- keep blocking/non-blocking reviewer semantics unchanged.

This was exposed by `mctlhq/mctl-gitops#1073`, where enabling `blocking: true` turned the previously masked reviewer execution failure into a real merge blocker.

Closes #39.