### PR TITLE
fix(agy): the previous diagnostics fix (#45) didn't actually disable -e

### DIFF
--- a/.github/workflows/agy-review.yml
+++ b/.github/workflows/agy-review.yml
@@ -257,16 +257,24 @@ jobs:
           set -uo pipefail
           export PATH="$HOME/.local/bin:$PATH"
 
-          # No `-e` here on purpose: agy exiting non-zero (quota exhaustion,
-          # a transient API error, ...) must not abort this script before it
-          # gets to read *why* from result.json. That bug shipped for two
-          # days — every failed run since 2026-09-07 printed only "Process
-          # completed with exit code 1" to the Actions log, because `set -e`
-          # killed the script on the `agy ...` line itself, before the
-          # status/error check below ever ran. The real reason sat in
-          # result.json on the runner the whole time, readable only by SSHing
-          # into the Mac mini. Every step from here on checks its own exit
-          # status explicitly instead of relying on set -e.
+          # `set -uo pipefail` does NOT turn off `-e`: GitHub's `shell: bash`
+          # invokes `bash --noprofile --norc -e -o pipefail {0}` at the
+          # process level regardless of what `set` command appears inside
+          # the script, and `set -uo pipefail` only ever touches `-u` and
+          # `pipefail` — it leaves whatever `-e` state was already active
+          # exactly as it was. The previous version of this fix (mctlhq/.github#45)
+          # believed dropping `set -e` from the script text was enough and
+          # was wrong: verified live on 2026-09-08 (mctl-telegram#576) that
+          # agy failing inside run_agy still aborted the script before a
+          # single diagnostic line was printed — the exact "Process
+          # completed with exit code 1" signature this was supposed to fix,
+          # confirmed by running the real invocation
+          # (`bash --noprofile --norc -e -o pipefail`) against this logic
+          # directly, not just `bash -n` syntax-checking it. Every `run_agy`
+          # call below is therefore explicitly exempted with `|| true` — a
+          # failing command as the condition of `||`/`&&`/`if` does not
+          # trigger `-e`, regardless of which flags are already active —
+          # rather than relying on the script having disabled it.
           run_agy() {
             # This file is consumed by every mctlhq repository the moment it
             # merges to main, with no per-repo rollout or version pin. A
@@ -289,7 +297,7 @@ jobs:
               > result.json
           }
 
-          run_agy "$AGY_HOME_PRIMARY"
+          run_agy "$AGY_HOME_PRIMARY" || true
           status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null); status="${status:-UNKNOWN}"
           error=$(jq -r '.error // ""' result.json 2>/dev/null)
 
@@ -326,7 +334,7 @@ jobs:
               # summary line still claimed a real account switch happened.
               echo "::warning::retrying on the fallback account"
               echo "agy: primary account out of quota, retried on the fallback account" >> "$GITHUB_STEP_SUMMARY"
-              run_agy "$AGY_HOME_FALLBACK"
+              run_agy "$AGY_HOME_FALLBACK" || true
               status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null); status="${status:-UNKNOWN}"
               error=$(jq -r '.error // ""' result.json 2>/dev/null)
             else

--- a/.github/workflows/agy-review.yml
+++ b/.github/workflows/agy-review.yml
@@ -254,27 +254,34 @@ jobs:
           AGY_MODEL: ${{ inputs.model }}
           AGY_EFFORT: ${{ inputs.effort }}
         run: |
-          set -uo pipefail
+          set -u
+
+          # `-e` is always on here regardless of this line: GitHub's
+          # `shell: bash` invokes `bash --noprofile --norc -e -o pipefail
+          # {0}` at the process level, independent of anything the script
+          # itself does. This `set` command only adds `-u` — `pipefail` is
+          # already active from that invocation, and there is no `set`
+          # spelling that turns `-e` back off once bash started with it.
+          # The previous version of this fix (mctlhq/.github#45) wrote
+          # `set -uo pipefail` believing it had dropped `-e`, and was
+          # wrong: verified live on 2026-09-08 (mctl-telegram#576) that agy
+          # failing inside run_agy still aborted the script before a
+          # single diagnostic line was printed — the exact "Process
+          # completed with exit code 1" signature that commit was supposed
+          # to fix, confirmed by running the real invocation
+          # (`bash --noprofile --norc -e -o pipefail`) against this logic
+          # directly, not just `bash -n` syntax-checking it. Every command
+          # below that is allowed to fail is therefore exempted at its own
+          # call site with `|| true`/`|| status=""` — a failing command as
+          # the condition of `||`/`&&`/`if` is the only thing bash does not
+          # apply errexit to, regardless of which flags are already active.
+          # When a function is called this way, bash suspends errexit for
+          # every command inside that call, not just the function's own
+          # return value — harmless here because in `run_agy` the `agy`
+          # invocation is the last command in the body, but worth knowing
+          # before adding a second failure-checking command after it.
           export PATH="$HOME/.local/bin:$PATH"
 
-          # `set -uo pipefail` does NOT turn off `-e`: GitHub's `shell: bash`
-          # invokes `bash --noprofile --norc -e -o pipefail {0}` at the
-          # process level regardless of what `set` command appears inside
-          # the script, and `set -uo pipefail` only ever touches `-u` and
-          # `pipefail` — it leaves whatever `-e` state was already active
-          # exactly as it was. The previous version of this fix (mctlhq/.github#45)
-          # believed dropping `set -e` from the script text was enough and
-          # was wrong: verified live on 2026-09-08 (mctl-telegram#576) that
-          # agy failing inside run_agy still aborted the script before a
-          # single diagnostic line was printed — the exact "Process
-          # completed with exit code 1" signature this was supposed to fix,
-          # confirmed by running the real invocation
-          # (`bash --noprofile --norc -e -o pipefail`) against this logic
-          # directly, not just `bash -n` syntax-checking it. Every `run_agy`
-          # call below is therefore explicitly exempted with `|| true` — a
-          # failing command as the condition of `||`/`&&`/`if` does not
-          # trigger `-e`, regardless of which flags are already active —
-          # rather than relying on the script having disabled it.
           run_agy() {
             # This file is consumed by every mctlhq repository the moment it
             # merges to main, with no per-repo rollout or version pin. A
@@ -298,8 +305,22 @@ jobs:
           }
 
           run_agy "$AGY_HOME_PRIMARY" || true
-          status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null); status="${status:-UNKNOWN}"
-          error=$(jq -r '.error // ""' result.json 2>/dev/null)
+          # `jq`'s own exit status is what `-e` sees here, independent of
+          # `run_agy`'s: a truncated result.json (agy killed mid-write by
+          # --print-timeout, job cancellation, OOM) or one holding a plain
+          # message instead of JSON both make jq exit non-zero, which would
+          # abort the script right here before a single diagnostic line
+          # printed — the same failure class the `|| true` above exists to
+          # prevent, one line later. An empty file is fine (jq exits 0 with
+          # no output, caught by the `:-UNKNOWN` default below); it's a
+          # non-empty, unparseable one that needs the exemption.
+          status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null) || status=""
+          status="${status:-UNKNOWN}"
+          error=$(jq -r '.error // ""' result.json 2>/dev/null) || error=""
+          # Falls back to the raw bytes so an operator sees the actual
+          # message agy wrote instead of a bare "status=UNKNOWN" when the
+          # file isn't valid JSON at all.
+          [ -n "$error" ] || error=$(head -c 500 result.json 2>/dev/null)
 
           # The one shape observed in production (2026-09-07/08) is agy's
           # own human-readable message, "Individual quota reached. Please
@@ -335,8 +356,10 @@ jobs:
               echo "::warning::retrying on the fallback account"
               echo "agy: primary account out of quota, retried on the fallback account" >> "$GITHUB_STEP_SUMMARY"
               run_agy "$AGY_HOME_FALLBACK" || true
-              status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null); status="${status:-UNKNOWN}"
-              error=$(jq -r '.error // ""' result.json 2>/dev/null)
+              status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null) || status=""
+              status="${status:-UNKNOWN}"
+              error=$(jq -r '.error // ""' result.json 2>/dev/null) || error=""
+              [ -n "$error" ] || error=$(head -c 500 result.json 2>/dev/null)
             else
               echo "::warning::$AGY_HOME_FALLBACK missing — no fallback account to retry on"
             fi

--- a/.github/workflows/agy-review.yml
+++ b/.github/workflows/agy-review.yml
@@ -304,23 +304,48 @@ jobs:
               > result.json
           }
 
+          # Reads result.json into $status/$error, tolerating every shape
+          # agy can leave behind. Both call sites need this, and it was
+          # got wrong twice already (mctlhq/.github#45, then #46's first
+          # commit) as duplicated inline code, so it is a function now —
+          # one place to fix instead of two to keep in sync.
+          read_result() {
+            # `jq`'s own exit status is what `-e` sees here, independent of
+            # `run_agy`'s: a truncated result.json (agy killed mid-write by
+            # --print-timeout, job cancellation, OOM) or one holding a plain
+            # message instead of JSON both make jq exit non-zero, which
+            # would abort the script here before a single diagnostic line
+            # printed — the same failure class `run_agy`'s own `|| true`
+            # exists to prevent, one step later. Every fallible read below
+            # is therefore the condition of its own `if`, not the trailing
+            # command of a `||` list — that trailing position is NOT exempt
+            # from errexit (only the earlier operands of `&&`/`||` are), so
+            # `cmd1 || fallback` still aborts if `fallback` itself fails.
+            if ! status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null); then
+              status="UNKNOWN"
+            fi
+            status="${status:-UNKNOWN}"
+
+            # The raw-bytes fallback below must trigger only when jq itself
+            # failed to parse the file — not whenever `.error` merely comes
+            # back empty, which is the normal shape of a well-formed
+            # result.json for a non-quota failure (`.error` genuinely
+            # absent). Gating on emptiness instead of on jq's exit status
+            # fed the FIRST 500 bytes of agy's raw response — a field this
+            # file elsewhere goes out of its way to treat as attacker-
+            # influenced (see the case match below) — into that same
+            # quota-retry decision, so a non-quota failure whose review
+            # text happened to mention "quota" would still burn a call on
+            # the personal fallback account.
+            if ! error=$(jq -r '.error // ""' result.json 2>/dev/null); then
+              if ! error=$(head -c 500 result.json 2>/dev/null); then
+                error=""
+              fi
+            fi
+          }
+
           run_agy "$AGY_HOME_PRIMARY" || true
-          # `jq`'s own exit status is what `-e` sees here, independent of
-          # `run_agy`'s: a truncated result.json (agy killed mid-write by
-          # --print-timeout, job cancellation, OOM) or one holding a plain
-          # message instead of JSON both make jq exit non-zero, which would
-          # abort the script right here before a single diagnostic line
-          # printed — the same failure class the `|| true` above exists to
-          # prevent, one line later. An empty file is fine (jq exits 0 with
-          # no output, caught by the `:-UNKNOWN` default below); it's a
-          # non-empty, unparseable one that needs the exemption.
-          status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null) || status=""
-          status="${status:-UNKNOWN}"
-          error=$(jq -r '.error // ""' result.json 2>/dev/null) || error=""
-          # Falls back to the raw bytes so an operator sees the actual
-          # message agy wrote instead of a bare "status=UNKNOWN" when the
-          # file isn't valid JSON at all.
-          [ -n "$error" ] || error=$(head -c 500 result.json 2>/dev/null)
+          read_result
 
           # The one shape observed in production (2026-09-07/08) is agy's
           # own human-readable message, "Individual quota reached. Please
@@ -356,10 +381,7 @@ jobs:
               echo "::warning::retrying on the fallback account"
               echo "agy: primary account out of quota, retried on the fallback account" >> "$GITHUB_STEP_SUMMARY"
               run_agy "$AGY_HOME_FALLBACK" || true
-              status=$(jq -r '.status // "UNKNOWN"' result.json 2>/dev/null) || status=""
-              status="${status:-UNKNOWN}"
-              error=$(jq -r '.error // ""' result.json 2>/dev/null) || error=""
-              [ -n "$error" ] || error=$(head -c 500 result.json 2>/dev/null)
+              read_result
             else
               echo "::warning::$AGY_HOME_FALLBACK missing — no fallback account to retry on"
             fi


### PR DESCRIPTION
## What broke

mctlhq/.github#45 replaced `set -euo pipefail` with `set -uo pipefail` in the `Run agy review` step, on the theory that this let the status/error check after `run_agy` run even when agy failed. It didn't.

GitHub's `shell: bash` invokes the interpreter as `bash --noprofile --norc -e -o pipefail {0}` **at the process level**, independent of anything the script itself does. `set -uo pipefail` only ever touches `-u` and `pipefail` — it has no effect on `-e` in either direction, so the `-e` from that invocation stayed on. Every diagnostic line after `run_agy "$AGY_HOME_PRIMARY"` was therefore still unreachable whenever agy failed: exactly the "Process completed with exit code 1" signature #45's own commit message describes as fixed.

## How it was caught

I opened a throwaway PR (mctl-telegram#576) specifically to verify #45 against a real `pull_request` event once merged — a rerun of the historical failing job doesn't work for this, because GitHub pins a reusable workflow's resolved content to the run that first triggered it, so rerunning an old job re-executes the *old* workflow text even when the caller references `@main`. The new PR reproduced the identical silent failure.

Confirmed the mechanism by extracting the literal `run:` block from the workflow YAML (not paraphrasing it) and executing it under `bash --noprofile --norc -e -o pipefail` — first against #45's merged text, which aborts before printing a single diagnostic line, then against this fix, exercised through all three paths with a stub `agy`:

| Scenario | Result |
| --- | --- |
| primary succeeds | reaches `review.md`, exit 0 |
| primary hits quota, fallback succeeds | `::warning::` × 2, `GITHUB_STEP_SUMMARY` written, reaches `review.md`, exit 0 |
| both fail | `::warning::`/`::error::` fully printed with the real error text, exit 1 |

The earlier round's verification only ran `bash -n`, which checks syntax, not `-e`'s actual runtime behavior under GitHub's real invocation flags — that gap is why it shipped broken.

## Fix

Exempt each `run_agy` call from `-e` explicitly with `|| true`. Bash does not apply errexit to a command that is the condition of `||`/`&&`/`if`, regardless of what invoked the shell or what `set` commands ran before it — that's a property of the call site, not of the shell's current `-e` state, which is why this is robust where toggling `set` was not.

## Notes for reviewers

Please don't approve this on the strength of the file reading correctly — run the actual repro if you want to check the claim, not just the diff. The exact commands are in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEXhd47oCkJMWbiaeecNZP