### PR TITLE
fix(agy): a run that reached no verdict no longer blocks a merge

### DIFF
--- a/.github/workflows/agy-review.yml
+++ b/.github/workflows/agy-review.yml
@@ -431,16 +431,32 @@ jobs:
             echo "<!-- agy-review -->"
             echo "## Antigravity (agy) review"
             echo ""
-            if [ "$BLOCKING" = "true" ]; then
-              echo "_agy run failed on this PR; see the workflow log. **Blocking merge until resolved.**_"
-            else
-              echo "_agy run failed on this PR; see the workflow log. Not blocking merge._"
-            fi
+            echo "_agy did not produce a review on this PR; see the workflow log. Not blocking merge — no verdict was reached, so there is nothing to act on._"
           } > comment.md
           gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file comment.md
+          # A run that never reached a verdict is not a review outcome, and it
+          # is deliberately not a merge blocker in either mode.
+          #
+          # It used to be, under blocking:true. What that actually gated on was
+          # the health of one machine and one subscription: on 2026-09-08 the
+          # primary Antigravity account hit "Individual quota reached ... Resets
+          # in 60h18m54s" (agy's own message, in the runner's CLI log for that
+          # run), the fallback did not carry it, and the step exited 1. Because
+          # mctl-agents lists `agy-review / review` among its required status
+          # checks, release 1.40.1 then sat unmergeable for a day — a fix that
+          # was already reviewed and approved, held up by a reviewer that never
+          # read it. Re-running the same job the next day passed with "No
+          # significant issues found", which is the tell: nothing about the diff
+          # had changed.
+          #
+          # Findings still block. `Check for P1/P2 findings` below fails on
+          # FAIL:P1/FAIL:P2 and fails closed on a missing or malformed verdict
+          # tag, because those are things the reviewer said about this diff.
+          # Quota, a dead language server, a missing HOME profile and a network
+          # error are not.
           if [ "$BLOCKING" = "true" ]; then
-            echo "::error::agy reviewer failed — blocking merge. See workflow log."
-            exit 1
+            echo "::warning::agy produced no review (see log). Not blocking: a run that reached no verdict says nothing about this diff."
+            echo "agy: no review produced — not blocking (see the workflow log)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Check for P1/P2 findings (blocking mode)


### PR DESCRIPTION
Refs #16. Separates "the reviewer had an opinion about this diff" from "the reviewer never ran".

## What went wrong, measured on the runner

`agy-review / review` failed on `mctlhq/mctl-agents#321` (the release PR for 1.40.1) and, because mctl-agents lists that check among its required status checks, held an already-approved, green-CI release for a day. The job's own log showed only `agy reviewer failed — blocking merge` and an exit after ~1.2s, with no findings.

The cause is in the agy CLI log on the self-hosted Mac mini, for that exact run (`~ghrunner/.gemini/antigravity-cli/log/cli-20260908_081453.log`):

```
session.go:226] Print mode: run ended with error and no response:
Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 60h18m54s.
```

The primary Antigravity account was out of quota and the fallback did not carry the run. Re-running the identical commit the next day produced `No significant issues found` / `VERDICT: PASS` — nothing about the diff had changed.

(The many `You are not logged into Antigravity` lines in the same log are a red herring: they appear in equal numbers in successful runs, emitted by a background experiments poller.)

## The change

In `Note agy failure`, blocking mode no longer exits 1. It posts the comment — now worded "did not produce a review" rather than "failed", which is what actually happened — and records a `::warning::` plus a step-summary line so the outage stays visible instead of silently green.

**Findings still block.** `Check for P1/P2 findings` is untouched: `FAIL:P1` / `FAIL:P2` fail the check, and a missing or malformed verdict tag still fails closed. Those are things the reviewer said about the diff. Quota, a dead language server, a missing `AGY_HOME_*` profile and a network error are not.

Non-blocking callers see no behavioural change beyond the clearer wording.

## Why not the alternatives

- **Remove `agy-review / review` from mctl-agents' required checks.** Fixes that one repository and leaves the same trap armed for every future caller that sets `blocking: true`. Worth doing as well, but it is a different decision and belongs to whoever owns that ruleset.
- **Keep blocking and rely on the fallback account.** The fallback already exists and did not save this run; it is a stopgap against one account's quota, not against the class of failure.
- **Retry on failure.** A quota window measured in tens of hours is not something a retry inside the same job can outlast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMqpQUQGPUiononB8fefNR